### PR TITLE
docs: update License and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,7 @@ Initial release of MLAPI Bitesize Samples repository. Samples support the follow
 
 - Added Invaders sample.
 - Added 2D Space Shooter sample.
+
+### License
+
+The Bitside Samples repository and code projects are licensed under the Unity Companion License for Unity-dependent projects (see https://unity3d.com/legal/licenses/unity_companion_license). See [LICENSE](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.bitesize/blob/master/LICENSE.md) for full details.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 Multiplayer Bitesize Samples Repository © 2021 Unity Technologies
 
-Licensed under the Unity Companion License for Unity-dependent projects (see https://unity3d.com/legal/licenses/unity_companion_license); otherwise licensed under the Unity Package Distribution License (see https://unity3d.com/legal/licenses/Unity_Package_Distribution_License).
+Licensed under the Unity Companion License for Unity-dependent projects (see https://unity3d.com/legal/licenses/unity_companion_license).
 
 Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. Please review the license for details on these and other terms and conditions.


### PR DESCRIPTION
Update LICENSE to only UCL. Add information to the changelog for licensing. As this has not released, adding it as part of the initial changelog.

Ticket: MTTSA-92