### PR TITLE
fix: fix naming of OnCollisionEnterCallback

### DIFF
--- a/Basic/2DSpaceShooter/Assets/Scripts/ShipControl.cs
+++ b/Basic/2DSpaceShooter/Assets/Scripts/ShipControl.cs
@@ -342,7 +342,7 @@ public class ShipControl : NetworkBehaviour
         }
     }
 
-    void OnCollision2DEnter(Collision2D other)
+    void OnCollisionEnter2D(Collision2D other)
     {
         if (NetworkManager.Singleton.IsServer)
         {


### PR DESCRIPTION
Shipcontrol had a wrongly named collision callback so it wasn't getting called.