### PR TITLE
chore: Add external ngo develop branch triggers

### DIFF
--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -53,3 +53,21 @@ develop_pull_request_trigger:
         only:
           - "main"
           - "develop"
+
+# Run all tasks on the bitesize sample develop branch (head) when there is a push to the Netcode for GameObjects develop branch
+external_ngo_develop_pull_request_trigger:
+  name: Netcode for GameObjects (External) Develop Branch Triggers
+  dependencies:
+{% for project in projects -%}
+{% for editor in test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+  triggers:
+    external:
+      source: git@github.com/Unity-Technologies/com.unity.netcode.gameobjects.git
+      expression: push.branch eq "develop"
+      refs_on_this_repository:
+        - develop


### PR DESCRIPTION
Add external triggers which check that bitesize develop projects still compile with latest NGO develop