### PR TITLE
fix: invaders late join issues

### DIFF
--- a/Basic/Invaders/Assets/Prefabs/player.prefab
+++ b/Basic/Invaders/Assets/Prefabs/player.prefab
@@ -110,6 +110,7 @@ MonoBehaviour:
   m_HitParticleSystem: {fileID: 2274621649305592229, guid: 4bf8467f048bdca478f6702a5286ef53,
     type: 3}
   m_PlayerColorInGame: {r: 0.32941177, g: 1, b: 0.19215687, a: 1}
+  m_PlayerVisual: {fileID: 21200000}
 --- !u!61 &6100000
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Basic/Invaders/Assets/Scripts/InvadersGame.cs
+++ b/Basic/Invaders/Assets/Scripts/InvadersGame.cs
@@ -148,7 +148,7 @@ public class InvadersGame : NetworkBehaviour
             m_Shields.Clear();
         }
 
-        NetworkManager.OnClientConnectedCallback -= OnClientConnected;
+        NetworkManager.Singleton.OnClientConnectedCallback -= OnClientConnected;
     }
 
     internal static event Action OnSingletonReady;
@@ -187,7 +187,7 @@ public class InvadersGame : NetworkBehaviour
 
         if (IsServer)
         {
-            NetworkManager.OnClientConnectedCallback += OnClientConnected;
+            NetworkManager.Singleton.OnClientConnectedCallback += OnClientConnected;
         }
 
         base.OnNetworkSpawn();

--- a/Basic/Invaders/Assets/Scripts/InvadersGame.cs
+++ b/Basic/Invaders/Assets/Scripts/InvadersGame.cs
@@ -147,6 +147,8 @@ public class InvadersGame : NetworkBehaviour
             m_Enemies.Clear();
             m_Shields.Clear();
         }
+
+        NetworkManager.OnClientConnectedCallback -= OnClientConnected;
     }
 
     internal static event Action OnSingletonReady;
@@ -183,7 +185,21 @@ public class InvadersGame : NetworkBehaviour
         //and in turn makes the players visible and allows for the players to be controlled.
         SceneTransitionHandler.sceneTransitionHandler.SetSceneState(SceneTransitionHandler.SceneStates.Ingame);
 
+        if (IsServer)
+        {
+            NetworkManager.OnClientConnectedCallback += OnClientConnected;
+        }
+
         base.OnNetworkSpawn();
+    }
+
+    private void OnClientConnected(ulong clientId)
+    {
+        if (m_ReplicatedTimeSent)
+        {
+            // Send the RPC only to the newly connected client
+            SetReplicatedTimeRemainingClientRPC(m_TimeRemaining, new ClientRpcParams {Send = new ClientRpcSendParams{TargetClientIds = new List<ulong>() {clientId}}});
+        }
     }
 
     /// <summary>
@@ -217,8 +233,9 @@ public class InvadersGame : NetworkBehaviour
     ///     will deal with updating it. For that, we use a ClientRPC
     /// </summary>
     /// <param name="delayedStartTime"></param>
+    /// <param name="clientRpcParams"></param>
     [ClientRpc]
-    private void SetReplicatedTimeRemainingClientRPC(float delayedStartTime)
+    private void SetReplicatedTimeRemainingClientRPC(float delayedStartTime, ClientRpcParams clientRpcParams = new ClientRpcParams())
     {
         // See the ShouldStartCountDown method for when the server updates the value
         if (m_TimeRemaining == 0)

--- a/Basic/Invaders/Assets/Scripts/MenuControl.cs
+++ b/Basic/Invaders/Assets/Scripts/MenuControl.cs
@@ -20,6 +20,7 @@ public class MenuControl : MonoBehaviour
         if (utpTransport) m_HostIpInput.text = "127.0.0.1";
         if (NetworkManager.Singleton.StartHost())
         {
+            SceneTransitionHandler.sceneTransitionHandler.RegisterCallbacks();
             SceneTransitionHandler.sceneTransitionHandler.SwitchScene(m_LobbySceneName);
         }
         else

--- a/Basic/Invaders/Assets/Scripts/PlayerControl.cs
+++ b/Basic/Invaders/Assets/Scripts/PlayerControl.cs
@@ -26,7 +26,6 @@ public class PlayerControl : NetworkBehaviour
     [SerializeField]
     Color m_PlayerColorInGame;
 
-    private SceneTransitionHandler.SceneStates m_CurrentSceneState;
     private bool m_HasGameStarted;
 
     private bool m_IsAlive = true;
@@ -36,6 +35,7 @@ public class PlayerControl : NetworkBehaviour
     private GameObject m_MyBullet;
     private ClientRpcParams m_OwnerRPCParams;
 
+    [SerializeField]
     private SpriteRenderer m_PlayerVisual;
     private NetworkVariable<int> m_Score = new NetworkVariable<int>(0);
 
@@ -46,15 +46,9 @@ public class PlayerControl : NetworkBehaviour
         m_HasGameStarted = false;
     }
 
-    private void Start()
-    {
-        m_PlayerVisual = GetComponent<SpriteRenderer>();
-        if (m_PlayerVisual != null) m_PlayerVisual.color = Color.clear;
-    }
-
     private void Update()
     {
-        switch (m_CurrentSceneState)
+        switch (SceneTransitionHandler.sceneTransitionHandler.GetCurrentSceneState())
         {
             case SceneTransitionHandler.SceneStates.Ingame:
             {
@@ -94,21 +88,14 @@ public class PlayerControl : NetworkBehaviour
         }
     }
 
-    private void SceneTransitionHandler_clientLoadedScene(ulong clientId)
-    {
-        SceneStateChangedClientRpc(m_CurrentSceneState);
-    }
-
-    [ClientRpc]
-    private void SceneStateChangedClientRpc(SceneTransitionHandler.SceneStates state)
-    {
-        if (!IsServer) SceneTransitionHandler.sceneTransitionHandler.SetSceneState(state);
-    }
-
     private void SceneTransitionHandler_sceneStateChanged(SceneTransitionHandler.SceneStates newState)
     {
-        m_CurrentSceneState = newState;
-        if (m_CurrentSceneState == SceneTransitionHandler.SceneStates.Ingame)
+        UpdateColor();
+    }
+
+    private void UpdateColor()
+    {
+        if (SceneTransitionHandler.sceneTransitionHandler.GetCurrentSceneState() == SceneTransitionHandler.SceneStates.Ingame)
         {
             if (m_PlayerVisual != null) m_PlayerVisual.color = m_PlayerColorInGame;
         }
@@ -133,10 +120,9 @@ public class PlayerControl : NetworkBehaviour
             InvadersGame.OnSingletonReady += SubscribeToDelegatesAndUpdateValues;
         else
             SubscribeToDelegatesAndUpdateValues();
-
-        if (IsServer) SceneTransitionHandler.sceneTransitionHandler.OnClientLoadedScene += SceneTransitionHandler_clientLoadedScene;
-
+        
         SceneTransitionHandler.sceneTransitionHandler.OnSceneStateChanged += SceneTransitionHandler_sceneStateChanged;
+        UpdateColor();
     }
 
     private void SubscribeToDelegatesAndUpdateValues()
@@ -149,6 +135,8 @@ public class PlayerControl : NetworkBehaviour
             InvadersGame.Singleton.SetScore(m_Score.Value);
             InvadersGame.Singleton.SetLives(m_Lives.Value);
         }
+
+        m_HasGameStarted = InvadersGame.Singleton.hasGameStarted.Value;
     }
 
     public void IncreasePlayerScore(int amount)

--- a/Basic/Invaders/Assets/Scripts/PlayerControl.cs
+++ b/Basic/Invaders/Assets/Scripts/PlayerControl.cs
@@ -153,8 +153,8 @@ public class PlayerControl : NetworkBehaviour
     private void OnLivesChanged(int previousAmount, int currentAmount)
     {
         // Hide graphics client side upon death
-        if (currentAmount <= 0 && IsClient && TryGetComponent<SpriteRenderer>(out var spriteRenderer))
-            spriteRenderer.enabled = false;
+        if (currentAmount <= 0 && IsClient)
+            m_PlayerVisual.enabled = false;
 
         if (!IsOwner) return;
         Debug.LogFormat("Lives {0} ", currentAmount);
@@ -225,8 +225,7 @@ public class PlayerControl : NetworkBehaviour
 
             // Hide graphics of this player object server-side. Note we don't want to destroy the object as it
             // may stop the RPC's from reaching on the other side, as there is only one player controlled object
-            if (TryGetComponent<SpriteRenderer>(out var spriteRenderer))
-                spriteRenderer.enabled = false;
+            m_PlayerVisual.enabled = false;
         }
         else
         {

--- a/Basic/Invaders/Assets/Scripts/SceneTransitionHandler.cs
+++ b/Basic/Invaders/Assets/Scripts/SceneTransitionHandler.cs
@@ -88,6 +88,15 @@ public class SceneTransitionHandler : NetworkBehaviour
     }
 
     /// <summary>
+    /// Registers callbacks to the NetworkSceneManager. This should be called when starting the server
+    /// </summary>
+    public void RegisterCallbacks()
+    {
+        NetworkManager.Singleton.SceneManager.OnLoadComplete += OnLoadComplete;
+        
+    }
+
+    /// <summary>
     /// Switches to a new scene
     /// </summary>
     /// <param name="scenename"></param>
@@ -96,8 +105,6 @@ public class SceneTransitionHandler : NetworkBehaviour
         if(NetworkManager.Singleton.IsListening)
         {
             m_numberOfClientLoaded = 0;
-            NetworkManager.Singleton.SceneManager.OnLoadComplete += OnLoadComplete;
-            NetworkManager.Singleton.SceneManager.OnLoadEventCompleted += OnLoadEventCompleted;
             NetworkManager.Singleton.SceneManager.LoadScene(scenename, LoadSceneMode.Single);
         }
         else
@@ -106,16 +113,10 @@ public class SceneTransitionHandler : NetworkBehaviour
         }
     }
 
-    void OnLoadComplete(ulong clientId, string sceneName, LoadSceneMode loadSceneMode)
+    private void OnLoadComplete(ulong clientId, string sceneName, LoadSceneMode loadSceneMode)
     {
         m_numberOfClientLoaded += 1;
         OnClientLoadedScene?.Invoke(clientId);
-    }
-
-    void OnLoadEventCompleted(string sceneName, LoadSceneMode loadSceneMode, List<ulong> clientsCompleted, List<ulong> clientsTimedOut)
-    {
-        NetworkManager.Singleton.SceneManager.OnLoadComplete -= OnLoadComplete;
-        NetworkManager.Singleton.SceneManager.OnLoadEventCompleted -= OnLoadEventCompleted;
     }
 
     public bool AllClientsAreLoaded()
@@ -129,6 +130,7 @@ public class SceneTransitionHandler : NetworkBehaviour
     /// </summary>
     public void ExitAndLoadStartMenu()
     {
+        NetworkManager.Singleton.SceneManager.OnLoadComplete -= OnLoadComplete;
         OnClientLoadedScene = null;
         SetSceneState(SceneStates.Start);
         SceneManager.LoadScene(1);


### PR DESCRIPTION
This PR fixes how player color is set so that it is set for late-joining players too. It also simplifies how the scene transition callbacks are setup and adds an RPC call to replicate the timer for late-joining players.

Fixes #28 