### PR TITLE
fix: fixing NotServerException [MTT-4029]

### DIFF
--- a/Basic/Invaders/Assets/Scripts/InvadersGame.cs
+++ b/Basic/Invaders/Assets/Scripts/InvadersGame.cs
@@ -452,7 +452,7 @@ public class InvadersGame : NetworkBehaviour
     [ClientRpc]
     public void BroadcastGameOverClientRpc(GameOverReason reason)
     {
-        var localPlayerObject = NetworkManager.Singleton.ConnectedClients[NetworkManager.Singleton.LocalClientId].PlayerObject;
+        var localPlayerObject = NetworkManager.Singleton.LocalClient.PlayerObject;
         Assert.IsNotNull(localPlayerObject);
 
         if (localPlayerObject.TryGetComponent<PlayerControl>(out var playerControl))


### PR DESCRIPTION
A call happening on the client to get its player object used a property that is only available to the server. This resulted in a NotServerException. This PR fixes this issue by instead using a property available on the client.