### PR TITLE
chore: ClientDriven LTS update to 2021.3.12f1

### DIFF
--- a/Basic/ClientDriven/Packages/manifest.json
+++ b/Basic/ClientDriven/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop",
-    "com.unity.netcode.gameobjects": "1.0.1",
+    "com.unity.netcode.gameobjects": "1.0.2",
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",

--- a/Basic/ClientDriven/Packages/manifest.json
+++ b/Basic/ClientDriven/Packages/manifest.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "1.15.16",
-    "com.unity.ide.rider": "3.0.13",
-    "com.unity.ide.visualstudio": "2.0.14",
+    "com.unity.collab-proxy": "1.17.2",
+    "com.unity.ide.rider": "3.0.15",
+    "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop",
-    "com.unity.netcode.gameobjects": "1.0.0",
+    "com.unity.netcode.gameobjects": "1.0.1",
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",

--- a/Basic/ClientDriven/Packages/manifest.json
+++ b/Basic/ClientDriven/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop",
-    "com.unity.netcode.gameobjects": "1.0.2",
+    "com.unity.netcode.gameobjects": "1.1.0",
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",

--- a/Basic/ClientDriven/Packages/packages-lock.json
+++ b/Basic/ClientDriven/Packages/packages-lock.json
@@ -112,12 +112,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.netcode.gameobjects": {
-      "version": "1.0.2",
+      "version": "1.1.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.2.0"
+        "com.unity.transport": "1.3.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -252,7 +252,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/Basic/ClientDriven/Packages/packages-lock.json
+++ b/Basic/ClientDriven/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "1.15.16",
+      "version": "1.17.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -43,7 +43,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.13",
+      "version": "3.0.15",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -52,7 +52,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.14",
+      "version": "2.0.16",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -68,7 +68,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.learn.iet-framework": {
-      "version": "2.2.1",
+      "version": "2.2.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -99,7 +99,7 @@
       "hash": "55bc606b0ae04e2368bdaeda903440570bd44900"
     },
     "com.unity.multiplayer.tools": {
-      "version": "1.0.0-pre.7",
+      "version": "1.0.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -112,12 +112,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.netcode.gameobjects": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.1.0"
+        "com.unity.transport": "1.2.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -130,7 +130,7 @@
     },
     "com.unity.nuget.newtonsoft-json": {
       "version": "3.0.2",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -143,19 +143,20 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.services.authentication": {
-      "version": "2.0.0",
-      "depth": 2,
+      "version": "2.2.0",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.nuget.newtonsoft-json": "3.0.2",
-        "com.unity.services.core": "1.3.1",
-        "com.unity.modules.unitywebrequest": "1.0.0"
+        "com.unity.services.core": "1.4.3",
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.ugui": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.services.core": {
-      "version": "1.4.0",
-      "depth": 2,
+      "version": "1.4.3",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.unitywebrequest": "1.0.0",
@@ -165,48 +166,48 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.services.lobby": {
-      "version": "1.0.0-pre.6",
+      "version": "1.0.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.services.core": "1.1.0-pre.10",
+        "com.unity.services.core": "1.4.0",
         "com.unity.modules.unitywebrequest": "1.0.0",
         "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
         "com.unity.modules.unitywebrequestaudio": "1.0.0",
         "com.unity.modules.unitywebrequesttexture": "1.0.0",
         "com.unity.modules.unitywebrequestwww": "1.0.0",
-        "com.unity.nuget.newtonsoft-json": "2.0.0",
-        "com.unity.services.authentication": "1.0.0-pre.6"
+        "com.unity.nuget.newtonsoft-json": "3.0.2",
+        "com.unity.services.authentication": "2.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.services.qos": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.unity.services.core": "1.3.2",
+        "com.unity.services.core": "1.4.0",
         "com.unity.modules.unitywebrequest": "1.0.0",
-        "com.unity.nuget.newtonsoft-json": "3.0.1",
+        "com.unity.nuget.newtonsoft-json": "3.0.2",
         "com.unity.services.authentication": "2.0.0",
         "com.unity.collections": "1.2.3"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.services.relay": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.services.core": "1.4.0",
         "com.unity.services.authentication": "2.0.0",
-        "com.unity.services.qos": "1.0.0",
+        "com.unity.services.qos": "1.0.1",
         "com.unity.modules.unitywebrequest": "1.0.0",
         "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
         "com.unity.modules.unitywebrequestaudio": "1.0.0",
         "com.unity.modules.unitywebrequesttexture": "1.0.0",
         "com.unity.modules.unitywebrequestwww": "1.0.0",
-        "com.unity.nuget.newtonsoft-json": "3.0.1",
+        "com.unity.nuget.newtonsoft-json": "3.0.2",
         "com.unity.transport": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -251,7 +252,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/Basic/ClientDriven/Packages/packages-lock.json
+++ b/Basic/ClientDriven/Packages/packages-lock.json
@@ -112,7 +112,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.netcode.gameobjects": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Basic/ClientDriven/ProjectSettings/ProjectVersion.txt
+++ b/Basic/ClientDriven/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.2f1
-m_EditorVersionWithRevision: 2021.3.2f1 (79cbdb13f624)
+m_EditorVersion: 2021.3.12f1
+m_EditorVersionWithRevision: 2021.3.12f1 (8af3c3e441b1)


### PR DESCRIPTION
Quick PR to update ClientDriven sample to the latest LTS version (2021.3.12f1).