### PR TITLE
feat: upgrade ClientDriven to NGO v1.2.0, cleaned up in-scene netvars

### DIFF
--- a/Basic/ClientDriven/Assets/Scenes/Bootstrap.unity
+++ b/Basic/ClientDriven/Assets/Scenes/Bootstrap.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.62097013, g: 0.5374908, b: 0.9638476, a: 1}
+  m_IndirectSpecularColor: {r: 0.21890283, g: 0.16790575, b: 0.67034173, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -184,6 +184,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
       propertyPath: CurrentIngredientType.m_InternalValue
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+      propertyPath: currentIngredientType.m_InternalValue
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8321201880322001125, guid: a6b33b41508134c09957e076f4d53415, type: 3}
@@ -620,6 +624,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
       propertyPath: CurrentIngredientType.m_InternalValue
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+      propertyPath: currentIngredientType.m_InternalValue
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8321201880322001125, guid: a6b33b41508134c09957e076f4d53415, type: 3}
@@ -1246,6 +1254,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
       propertyPath: CurrentIngredientType.m_InternalValue
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+      propertyPath: currentIngredientType.m_InternalValue
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8321201880322001125, guid: a6b33b41508134c09957e076f4d53415, type: 3}
@@ -1928,6 +1940,10 @@ PrefabInstance:
       propertyPath: m_StartingIngredientType
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2422379464697062703, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
+      propertyPath: currentIngredientType.m_InternalValue
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2560790651037395570, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
       propertyPath: GlobalObjectIdHash
       value: 2634250759
@@ -1938,6 +1954,10 @@ PrefabInstance:
       objectReference: {fileID: 1299635455}
     - target: {fileID: 2695509083640791865, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
       propertyPath: m_StartingIngredientType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2695509083640791865, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
+      propertyPath: currentIngredientType.m_InternalValue
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3270690903589593812, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}

--- a/Basic/ClientDriven/Packages/manifest.json
+++ b/Basic/ClientDriven/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.inputsystem": "1.4.4",
     "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop",
-    "com.unity.netcode.gameobjects": "1.1.0",
+    "com.unity.netcode.gameobjects": "https://github.com/Unity-Technologies/com.unity.netcode.gameobjects.git?path=/com.unity.netcode.gameobjects#release/1.2.0",
     "com.unity.render-pipelines.universal": "12.1.8",
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",

--- a/Basic/ClientDriven/Packages/packages-lock.json
+++ b/Basic/ClientDriven/Packages/packages-lock.json
@@ -128,14 +128,14 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.netcode.gameobjects": {
-      "version": "1.1.0",
+      "version": "https://github.com/Unity-Technologies/com.unity.netcode.gameobjects.git?path=/com.unity.netcode.gameobjects#release/1.2.0",
       "depth": 0,
-      "source": "registry",
+      "source": "git",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "1.10.1",
         "com.unity.transport": "1.3.0"
       },
-      "url": "https://packages.unity.com"
+      "hash": "ce1869fbe208019d1fd257a993ef03dca9e025ca"
     },
     "com.unity.nuget.mono-cecil": {
       "version": "1.10.1",


### PR DESCRIPTION
This PR upgrades ClientDriven bitesize sample to NGO v1.2.0.

Included in this NGO version is a fix to the serialization of in-scene placed NetworkObjects, resolving a known issue on non-red ingredients, stoves, and dropzones.

I'll update the manifest once again when the NGO release is out.