### PR TITLE
fix: ClientDriven initial position sync fix on owning clients

### DIFF
--- a/Basic/ClientDriven/Assets/Prefabs/PlayerArmature_Networked.prefab
+++ b/Basic/ClientDriven/Assets/Prefabs/PlayerArmature_Networked.prefab
@@ -126,6 +126,10 @@ PrefabInstance:
       propertyPath: GroundLayers.m_Bits
       value: 640
       objectReference: {fileID: 0}
+    - target: {fileID: 4416926081852918491, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4416926081852918493, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
       propertyPath: m_Actions
       value: 

--- a/Basic/ClientDriven/Assets/Scripts/ClientPlayerMove.cs
+++ b/Basic/ClientDriven/Assets/Scripts/ClientPlayerMove.cs
@@ -64,6 +64,9 @@ public class ClientPlayerMove : NetworkBehaviour
         // player input is only enabled on owning players
         m_PlayerInput.enabled = true;
         m_ThirdPersonController.enabled = true;
+        
+        // see the note inside ServerPlayerMove why this step is also necessary for synchronizing initial player
+        // position on owning clients
         m_CharacterController.enabled = true;
 
         var cinemachineVirtualCamera = FindObjectOfType<CinemachineVirtualCamera>();

--- a/Basic/ClientDriven/Assets/Scripts/ClientPlayerMove.cs
+++ b/Basic/ClientDriven/Assets/Scripts/ClientPlayerMove.cs
@@ -45,6 +45,7 @@ public class ClientPlayerMove : NetworkBehaviour
         // ghost clients.
         m_ThirdPersonController.enabled = false;
         m_CapsuleCollider.enabled = false;
+        m_CharacterController.enabled = false;
     }
 
     public override void OnNetworkSpawn()
@@ -63,6 +64,7 @@ public class ClientPlayerMove : NetworkBehaviour
         // player input is only enabled on owning players
         m_PlayerInput.enabled = true;
         m_ThirdPersonController.enabled = true;
+        m_CharacterController.enabled = true;
 
         var cinemachineVirtualCamera = FindObjectOfType<CinemachineVirtualCamera>();
         cinemachineVirtualCamera.Follow = m_CameraFollow;
@@ -98,14 +100,5 @@ public class ClientPlayerMove : NetworkBehaviour
                 }
             }
         }
-    }
-
-    [ClientRpc]
-    public void SetSpawnClientRpc(Vector3 position, ClientRpcParams clientRpcParams = default)
-    {
-        m_CharacterController.enabled = false;
-        transform.position = position;
-        m_CharacterController.enabled = true;
-        gameObject.SetActive(true);
     }
 }

--- a/Basic/ClientDriven/Assets/Scripts/ServerPlayerMove.cs
+++ b/Basic/ClientDriven/Assets/Scripts/ServerPlayerMove.cs
@@ -37,6 +37,15 @@ public class ServerPlayerMove : NetworkBehaviour
         var spawnPoint = ServerPlayerSpawnPoints.Instance.ConsumeNextSpawnPoint();
         var spawnPosition = spawnPoint ? spawnPoint.transform.position : Vector3.zero;
         transform.position = spawnPosition;
+        
+        // A note specific to owner authority:
+        // Side Note:  Specific to Owner Authoritative
+        // Setting the position works as and can be set in OnNetworkSpawn server-side unless there is a
+        // CharacterController that is enabled by default on the authoritative side. With CharacterController, it
+        // needs to be disabled by default (i.e. in Awake), the server applies the position (OnNetworkSpawn), and then
+        // the owner of the NetworkObject should enable CharacterController during OnNetworkSpawn. Otherwise,
+        // CharacterController will initialize itself with the initial position (before synchronization) and updates the
+        // transform after synchronization with the initial position, thus overwriting the synchronized position.
     }
 
     [ServerRpc]

--- a/Basic/ClientDriven/Assets/Scripts/ServerPlayerMove.cs
+++ b/Basic/ClientDriven/Assets/Scripts/ServerPlayerMove.cs
@@ -10,9 +10,6 @@ using UnityEngine;
 [DefaultExecutionOrder(0)] // before client component
 public class ServerPlayerMove : NetworkBehaviour
 {
-    [SerializeField]
-    ClientPlayerMove m_ClientPlayerMove;
-
     public NetworkVariable<bool> isObjectPickedUp = new NetworkVariable<bool>();
     
     NetworkObject m_PickedUpObject;
@@ -23,7 +20,6 @@ public class ServerPlayerMove : NetworkBehaviour
     // DOC START HERE
     public override void OnNetworkSpawn()
     {
-        base.OnNetworkSpawn();
         if (!IsServer)
         {
             enabled = false;
@@ -31,6 +27,8 @@ public class ServerPlayerMove : NetworkBehaviour
         }
 
         OnServerSpawnPlayer();
+        
+        base.OnNetworkSpawn();
     }
 
     void OnServerSpawnPlayer()
@@ -38,9 +36,7 @@ public class ServerPlayerMove : NetworkBehaviour
         // this is done server side, so we have a single source of truth for our spawn point list
         var spawnPoint = ServerPlayerSpawnPoints.Instance.ConsumeNextSpawnPoint();
         var spawnPosition = spawnPoint ? spawnPoint.transform.position : Vector3.zero;
-        // using client RPC since ClientNetworkTransform can only be modified by owner (which is client side)
-        m_ClientPlayerMove.SetSpawnClientRpc(spawnPosition, 
-            new ClientRpcParams() { Send = new ClientRpcSendParams() { TargetClientIds = new []{OwnerClientId}}});
+        transform.position = spawnPosition;
     }
 
     [ServerRpc]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Upgrade to Netcode for GameObjects v1.2.0 & cleaned up in-scene NetworkVariables (#78)
 - Ingredient spawn position offset (#81)
 - In-game UI backgrounds (#82)
+- Initial position sync fix on owning clients (#85)
 
 ### 2DSpaceShooter
 


### PR DESCRIPTION
PR that includes a better flow for synchronizing initial position on clients that isn't dependent on ClientRpcs. The position of owning clients is still set server-side, and it guarantees no race conditions with CharacterController's initialization.