### PR TITLE
Fix: Broken Reference for Underline Character in Font Asset (2D Space Shooter) [MTT-5223]

### DIFF
--- a/Basic/2DSpaceShooter/Assets/Fonts/chintzy SDF.asset
+++ b/Basic/2DSpaceShooter/Assets/Fonts/chintzy SDF.asset
@@ -1076,7 +1076,7 @@ MonoBehaviour:
     m_GlyphIndex: 89
     m_Scale: 1
   - m_ElementType: 1
-    m_Unicode: 45
+    m_Unicode: 95
     m_GlyphIndex: 14
     m_Scale: 1
   - m_ElementType: 1


### PR DESCRIPTION
Updated font asset to have correct Unicode hex for the underline character--this stops a couple of warnings from being spammed in the console

```
The character used for Underline is not available in font asset [chintzy SDF].
UnityEngine.GUIUtility:ProcessEvent (int,intptr,bool&)
```

and 

```
The character used for Underline is not available in font asset [chintzy SDF].
UnityEngine.UIElements.UIElementsRuntimeUtilityNative:UpdateRuntimePanels ()
```

### Issue Number(s)
[Jira ticket [MTT-5223] here](https://jira.unity3d.com/browse/MTT-5223)

### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
