### PR TITLE
fix: bullet explosion desync [MTT-5080]

### DIFF
--- a/Basic/2DSpaceShooter/Assets/Prefabs/Bullet.prefab
+++ b/Basic/2DSpaceShooter/Assets/Prefabs/Bullet.prefab
@@ -14,8 +14,6 @@ GameObject:
   - component: {fileID: 5800000}
   - component: {fileID: 11400004}
   - component: {fileID: -4113703611147433057}
-  - component: {fileID: -2419440837048175228}
-  - component: {fileID: -7548598001898569089}
   m_Layer: 0
   m_Name: Bullet
   m_TagString: Untagged
@@ -33,6 +31,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 17.05494, y: -1.1583278, z: 0}
   m_LocalScale: {x: 0.6, y: 0.6, z: 0.6}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6681543778280045604}
   - {fileID: 2541587719488337929}
@@ -51,6 +50,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -157,45 +157,6 @@ MonoBehaviour:
   AlwaysReplicateAsRoot: 0
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 0
---- !u!114 &-2419440837048175228
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 100000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  SyncPositionX: 1
-  SyncPositionY: 1
-  SyncPositionZ: 1
-  SyncRotAngleX: 1
-  SyncRotAngleY: 1
-  SyncRotAngleZ: 1
-  SyncScaleX: 1
-  SyncScaleY: 1
-  SyncScaleZ: 1
-  PositionThreshold: 0.001
-  RotAngleThreshold: 0.01
-  ScaleThreshold: 0.01
-  InLocalSpace: 0
-  Interpolate: 1
-  CanCommitToTransform: 0
---- !u!114 &-7548598001898569089
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 100000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 80d7c879794dfda4687da0e400131852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1734169577680067239
 GameObject:
   m_ObjectHideFlags: 0
@@ -223,6 +184,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.6666665, y: 1.6666665, z: 1.6666665}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 400000}
   m_RootOrder: 0
@@ -239,6 +201,7 @@ TrailRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -361,6 +324,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.6784176, y: 0.6784176, z: 0.6784176}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 400000}
   m_RootOrder: 2
@@ -376,6 +340,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -443,6 +408,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.2764332, y: 1.2764332, z: 1.2764332}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 400000}
   m_RootOrder: 1
@@ -459,6 +425,7 @@ TrailRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0

--- a/Basic/2DSpaceShooter/Assets/Scripts/Bullet.cs
+++ b/Basic/2DSpaceShooter/Assets/Scripts/Bullet.cs
@@ -38,6 +38,26 @@ public class Bullet : NetworkBehaviour
         NetworkObject.Despawn(true);
     }
 
+    public void SetVelocity(Vector2 velocity)
+    {
+        if (IsServer)
+        {
+            var bulletRb = GetComponent<Rigidbody2D>();
+            bulletRb.velocity = velocity;
+            SetVelocityClientRpc(velocity);
+        }
+    }
+
+    [ClientRpc]
+    void SetVelocityClientRpc(Vector2 velocity)
+    {
+        if (!IsHost)
+        {
+            var bulletRb = GetComponent<Rigidbody2D>();
+            bulletRb.velocity = velocity;
+        }
+    }
+
     void OnCollisionEnter2D(Collision2D other)
     {
         var otherObject = other.gameObject;

--- a/Basic/2DSpaceShooter/Assets/Scripts/ShipControl.cs
+++ b/Basic/2DSpaceShooter/Assets/Scripts/ShipControl.cs
@@ -196,23 +196,24 @@ public class ShipControl : NetworkBehaviour
     {
         fireSound.Play();
 
-        int damage = 5;
+        var damage = 5;
         if (QuadDamageTimer.Value > NetworkManager.ServerTime.TimeAsFloat)
         {
             damage = 20;
         }
 
-        bool bounce = BounceTimer.Value > NetworkManager.ServerTime.TimeAsFloat;
+        var bounce = BounceTimer.Value > NetworkManager.ServerTime.TimeAsFloat;
 
-        GameObject bullet = m_ObjectPool.GetNetworkObject(BulletPrefab).gameObject;
-        bullet.transform.position = transform.position + direction;
+        var bulletGo = m_ObjectPool.GetNetworkObject(BulletPrefab).gameObject;
+        bulletGo.transform.position = transform.position + direction;
 
-        var bulletRb = bullet.GetComponent<Rigidbody2D>();
         var velocity = m_Rigidbody2D.velocity;
         velocity += (Vector2)(direction) * 10;
-        bulletRb.velocity = velocity;
-        bullet.GetComponent<Bullet>().Config(this, damage, bounce, m_BulletLifetime);
-        bullet.GetComponent<NetworkObject>().Spawn(true);
+        bulletGo.GetComponent<NetworkObject>().Spawn(true);
+        var bullet = bulletGo.GetComponent<Bullet>();
+        bullet.Config(this, damage, bounce, m_BulletLifetime);
+        bullet.SetVelocity(velocity);
+        
     }
 
     void Update()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [unreleased] - yyyy-mm-dd
 
+### 2DSpaceShooter
+
+### Fixed
+- Fixing bullet explosion desync (#89). Bullet explosion vfx were happening too early on clients because of NetworkTransform's interpolation. Bullets are now no longer synchronised by NetworkTransforms and instead only have their velocity set through client rpcs when they are spawned. Since they are no longer interpolated, they are not lagging behind the server and are at the correct position when they receive the despawn message from the server.
+
 ## [1.1.0] - 2022-12-13
 
 ### Client Driven


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
Because of NetworkTransform's interpolation, the bullets' explosion vfx were happening too early on clients. This PR fixes this by removing the NetworkTransform entirely. Bullets are now spawned and initialized on the server and clients handle their movement locally. Collision detection still happens only on the server. The result is that bullets' positions are no longer synchronized and interpolated. It is thus possible that a small desync happens during a bullet's lifetime, but since it is quite short it wouldn't cause issues. Plus, it would only be a visual artifact since all gameplay logic is still server-driven.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
[MTT-5080](https://jira.unity3d.com/browse/MTT-5080)

### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
