### PR TITLE
fix: removing warning when spawning powerups

### DIFF
--- a/Basic/2DSpaceShooter/Assets/Scripts/Spawner.cs
+++ b/Basic/2DSpaceShooter/Assets/Scripts/Spawner.cs
@@ -152,8 +152,8 @@ public class Spawner : MonoBehaviour
 
             GameObject powerUp = m_ObjectPool.GetNetworkObject(m_PowerupPrefab).gameObject;
             powerUp.transform.position = pos;
-            powerUp.GetComponent<Powerup>().buffType.Value = (Buff.BuffType)Random.Range(0, (int)Buff.BuffType.Last);
             powerUp.GetComponent<NetworkObject>().Spawn(true);
+            powerUp.GetComponent<Powerup>().buffType.Value = (Buff.BuffType)Random.Range(0, (int)Buff.BuffType.Last);
         }
 
         if (Asteroid.numAsteroids == 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [unreleased] - yyyy-mm-dd
 
+### 2DSpaceShooter
+
+### Fixed
+- Removing warning when spawning powerups (#90). Fixed the order in which powerups were spawned and when their NetworkVariable value was initialized. Now they are spawned beforehand.
+
 ## [1.1.0] - 2022-12-13
 
 ### Client Driven


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
This simply moves the update to the powerups' `buffType` NetworkVariable to after they are spawned to remove the warnings in the console.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
None

### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
