### PR TITLE
fix: dynamic prefabs loaded status correctly shown on host

### DIFF
--- a/Basic/DynamicAddressablesNetworkPrefabs/Assets/Scripts/02_Server Authoritative Load All Async/ServerAuthoritativeLoadAllAsync.cs
+++ b/Basic/DynamicAddressablesNetworkPrefabs/Assets/Scripts/02_Server Authoritative Load All Async/ServerAuthoritativeLoadAllAsync.cs
@@ -183,7 +183,7 @@ namespace Game.ServerAuthoritativeLoadAllAsync
                     m_InGameUI.ClientLoadedPrefabStatusChanged(client,
                         assetGuid.GetHashCode(), 
                         loadedGameObject.Result.name, 
-                        InGameUI.LoadStatus.Loading);
+                        InGameUI.LoadStatus.Loaded);
                 }
             }
         }

--- a/Basic/DynamicAddressablesNetworkPrefabs/Assets/Scripts/03_Server Authoritative Synchronous Spawning/ServerAuthoritativeSynchronousSpawning.cs
+++ b/Basic/DynamicAddressablesNetworkPrefabs/Assets/Scripts/03_Server Authoritative Synchronous Spawning/ServerAuthoritativeSynchronousSpawning.cs
@@ -227,7 +227,7 @@ namespace Game.ServerAuthoritativeSynchronousSpawning
                     m_InGameUI.ClientLoadedPrefabStatusChanged(client, 
                         assetGuid.GetHashCode(), 
                         prefab.Result.name, 
-                        InGameUI.LoadStatus.Loading);
+                        InGameUI.LoadStatus.Loaded);
                 }
                 
                 return obj;

--- a/Basic/DynamicAddressablesNetworkPrefabs/Assets/Scripts/05_API Playground/APIPlayground.cs
+++ b/Basic/DynamicAddressablesNetworkPrefabs/Assets/Scripts/05_API Playground/APIPlayground.cs
@@ -246,7 +246,7 @@ namespace Game.APIPlayground
                     m_InGameUI.ClientLoadedPrefabStatusChanged(client,
                         assetGuid.GetHashCode(), 
                         loadedGameObject.Result.name, 
-                        InGameUI.LoadStatus.Loading);
+                        InGameUI.LoadStatus.Loaded);
                 }
             }
         }


### PR DESCRIPTION
### Description
Quick PR to fix Loaded status name not displaying on loaded prefabs. This is just a visuals bug-fix. Implementation remains the same.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
N/A
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
