### PR TITLE
fix: applying address inside TMP field to UTP connection data as host

### DIFF
--- a/Basic/Invaders/Assets/Scenes/StartMenu.unity
+++ b/Basic/Invaders/Assets/Scenes/StartMenu.unity
@@ -436,6 +436,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2d49b7c1bcd2e07499844da127be038d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_ForceModuleActive: 0
 --- !u!114 &388206763
 MonoBehaviour:
@@ -449,6 +450,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -575,7 +577,7 @@ GameObject:
   - component: {fileID: 604336998}
   - component: {fileID: 604336997}
   m_Layer: 5
-  m_Name: StartLocalButton
+  m_Name: StartButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -650,7 +652,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 698002439}
         m_TargetAssemblyTypeName: 
-        m_MethodName: StartLocalGame
+        m_MethodName: StartGame
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -947,7 +949,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f6caebb4c9b3cb4abe107a550d8ed9a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_HostIpInput: {fileID: 1160858181}
+  m_IPAddressText: {fileID: 0}
   m_LobbySceneName: InvadersLobby
 --- !u!1 &1016699296
 GameObject:
@@ -2085,7 +2087,7 @@ GameObject:
   - component: {fileID: 1810564612}
   - component: {fileID: 1810564611}
   m_Layer: 5
-  m_Name: JoinLocalButton
+  m_Name: JoinButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2160,7 +2162,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 698002439}
         m_TargetAssemblyTypeName: 
-        m_MethodName: JoinLocalGame
+        m_MethodName: JoinGame
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Basic/Invaders/Assets/Scenes/StartMenu.unity
+++ b/Basic/Invaders/Assets/Scenes/StartMenu.unity
@@ -949,7 +949,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f6caebb4c9b3cb4abe107a550d8ed9a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_IPAddressText: {fileID: 0}
+  m_IPAddressText: {fileID: 1160858181}
   m_LobbySceneName: InvadersLobby
 --- !u!1 &1016699296
 GameObject:

--- a/Basic/Invaders/Assets/Scripts/MenuControl.cs
+++ b/Basic/Invaders/Assets/Scripts/MenuControl.cs
@@ -14,7 +14,6 @@ public class MenuControl : MonoBehaviour
 
     public void StartGame()
     {
-        // Update the current HostNameInput with whatever we have set in the NetworkConfig as default
         var utpTransport = (UnityTransport)NetworkManager.Singleton.NetworkConfig.NetworkTransport;
         if (utpTransport)
         {

--- a/Basic/Invaders/Assets/Scripts/MenuControl.cs
+++ b/Basic/Invaders/Assets/Scripts/MenuControl.cs
@@ -3,21 +3,23 @@ using TMPro;
 using Unity.Netcode;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
-using UnityEngine.UI;
 
 public class MenuControl : MonoBehaviour
 {
     [SerializeField]
-    private TMP_Text m_HostIpInput;
+    TMP_Text m_IPAddressText;
 
     [SerializeField]
-    private string m_LobbySceneName = "InvadersLobby";
+    string m_LobbySceneName = "InvadersLobby";
 
-    public void StartLocalGame()
+    public void StartGame()
     {
         // Update the current HostNameInput with whatever we have set in the NetworkConfig as default
         var utpTransport = (UnityTransport)NetworkManager.Singleton.NetworkConfig.NetworkTransport;
-        if (utpTransport) m_HostIpInput.text = "127.0.0.1";
+        if (utpTransport)
+        {
+            utpTransport.SetConnectionData(Sanitize(m_IPAddressText.text), 7777);
+        }
         if (NetworkManager.Singleton.StartHost())
         {
             SceneTransitionHandler.sceneTransitionHandler.RegisterCallbacks();
@@ -29,23 +31,20 @@ public class MenuControl : MonoBehaviour
         }
     }
 
-    public void JoinLocalGame()
+    public void JoinGame()
     {
-        if (m_HostIpInput.text != "Hostname")
+        var utpTransport = (UnityTransport)NetworkManager.Singleton.NetworkConfig.NetworkTransport;
+        if (utpTransport)
         {
-            var utpTransport = (UnityTransport)NetworkManager.Singleton.NetworkConfig.NetworkTransport;
-            if (utpTransport)
-            {
-                utpTransport.SetConnectionData(Sanitize(m_HostIpInput.text), 7777);
-            }
-            if (!NetworkManager.Singleton.StartClient())
-            {
-                Debug.LogError("Failed to start client.");
-            }
+            utpTransport.SetConnectionData(Sanitize(m_IPAddressText.text), 7777);
+        }
+        if (!NetworkManager.Singleton.StartClient())
+        {
+            Debug.LogError("Failed to start client.");
         }
     }
     
-    public static string Sanitize(string dirtyString)
+    static string Sanitize(string dirtyString)
     {
         // sanitize the input for the ip address
         return Regex.Replace(dirtyString, "[^A-Za-z0-9.]", "");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change log
 
 ## [unreleased] - yyyy-mm-dd
-N/A
+
+### Invaders
+
+#### Fixed
+- IP address input field text value is now passed into UTP's ConnectionData, allowing for remote IP address hosting (#112)
 
 ## [1.2.1] - 2023-02-17
 


### PR DESCRIPTION
<!-- DO NOT REMOVE BEGIN -->
[style guide]: https://unity-docs.gitbook.io/style-guide/
[release note guide lines]: https://unity-docs.gitbook.io/style-guide/style/release-notes
[coding conventions]: https://github.cds.internal.unity3d.com/unity/unity-meta/blob/stable/ReferenceSource/CSharp/Assets/CSharpReference.cs
<!-- DO NOT REMOVE END -->

### Proposed change(s)

Invaders didn't previously allow for passing in the IP address' input field text value into UTP's connection data and only allowed local hosting (127.0.0.1). This PR adds that functionality to the Invaders sample, allowing the ability to connect to a remote IP address.

### Platform and Editor version used to develop and test this PR
- Windows, 2021.3.18f1

### Related links
- N/A

### Affected sample(s)

- [ ] 2DSpaceShooter
- [x] Invaders
- [ ] Client Driven
- [ ] Dynamic Addressables Network Prefabs
- [ ] N/A (please describe)

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] UI/UX (see [style guide] and add Jil as a reviewer for relevant changes)
- [ ] Breaking change
- [ ] Documentation update (see [style guide])

### Checklist
- [ ] Unit tests pass locally --> n/a right now
- [ ] Added tests, if feasible, that prove my fix is effective or that my feature works 
- [x] No warnings in the Console
- [ ] Documented (///) **public APIs** (public/protected functionality of public/protected classes), if applicable
- [ ] Updated the sample documentation, if applicable (see [style guide])
- [ ] UI & Style sheet changes: both Dark and Light styles/themes updated/tested --> n/a right now
- Remember to familiarize yourself with the [coding conventions]

### How to test/validate

1. Clone this branch
2. Open it with the aforementioned Unity version
3. Create a build.
4. Host and set public IP for the connect address.
5. Have a client join the host.
6. Both clients should be sent to the pre-game lobby.

### Other comments
N/A
