### PR TITLE
fix: 2DSpaceShooter, ClientDriven, & Invaders point to v2.2.0 Samples Utilities package

### DIFF
--- a/Basic/2DSpaceShooter/Packages/manifest.json
+++ b/Basic/2DSpaceShooter/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.unity.ide.rider": "3.0.21",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop",
+    "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop#v2.2.0",
     "com.unity.netcode.gameobjects": "1.4.0",
     "com.unity.postprocessing": "3.2.2",
     "com.unity.render-pipelines.universal": "14.0.7",

--- a/Basic/2DSpaceShooter/Packages/packages-lock.json
+++ b/Basic/2DSpaceShooter/Packages/packages-lock.json
@@ -98,19 +98,19 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.multiplayer.samples.coop": {
-      "version": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop",
+      "version": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop#v2.2.0",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.learn.iet-framework": "1.2.1",
-        "com.unity.multiplayer.tools": "1.0.0",
-        "com.unity.netcode.gameobjects": "1.1.0",
+        "com.unity.multiplayer.tools": "1.1.0",
+        "com.unity.netcode.gameobjects": "1.4.0",
         "com.unity.services.relay": "1.0.3"
       },
-      "hash": "782ce810febe13fc4b68235389a0f3224b2418d2"
+      "hash": "0cd402eaea1969d4e9f894a5bc6c90432e12ab02"
     },
     "com.unity.multiplayer.tools": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/Basic/ClientDriven/Assets/Prefabs/PlayerArmature_Networked.prefab
+++ b/Basic/ClientDriven/Assets/Prefabs/PlayerArmature_Networked.prefab
@@ -133,7 +133,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4416926081852918490, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
       propertyPath: GroundLayers.m_Bits
-      value: 640
+      value: 128
       objectReference: {fileID: 0}
     - target: {fileID: 4416926081852918491, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
       propertyPath: m_Enabled

--- a/Basic/ClientDriven/Packages/manifest.json
+++ b/Basic/ClientDriven/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.inputsystem": "1.5.1",
-    "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop",
+    "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop#v2.2.0",
     "com.unity.netcode.gameobjects": "1.4.0",
     "com.unity.render-pipelines.universal": "14.0.7",
     "com.unity.test-framework": "1.1.33",

--- a/Basic/ClientDriven/Packages/packages-lock.json
+++ b/Basic/ClientDriven/Packages/packages-lock.json
@@ -110,19 +110,19 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.multiplayer.samples.coop": {
-      "version": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop",
+      "version": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop#v2.2.0",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.learn.iet-framework": "1.2.1",
-        "com.unity.multiplayer.tools": "1.0.0",
-        "com.unity.netcode.gameobjects": "1.1.0",
+        "com.unity.multiplayer.tools": "1.1.0",
+        "com.unity.netcode.gameobjects": "1.4.0",
         "com.unity.services.relay": "1.0.3"
       },
-      "hash": "782ce810febe13fc4b68235389a0f3224b2418d2"
+      "hash": "0cd402eaea1969d4e9f894a5bc6c90432e12ab02"
     },
     "com.unity.multiplayer.tools": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/Basic/Invaders/Packages/manifest.json
+++ b/Basic/Invaders/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.ide.rider": "3.0.21",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop",
+    "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop#v2.2.0",
     "com.unity.multiplayer.tools": "1.0.0",
     "com.unity.netcode.gameobjects": "1.4.0",
     "com.unity.render-pipelines.universal": "14.0.7",

--- a/Basic/Invaders/Packages/packages-lock.json
+++ b/Basic/Invaders/Packages/packages-lock.json
@@ -91,20 +91,20 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.multiplayer.samples.coop": {
-      "version": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop",
+      "version": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop#v2.2.0",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.learn.iet-framework": "1.2.1",
-        "com.unity.multiplayer.tools": "1.0.0",
-        "com.unity.netcode.gameobjects": "1.1.0",
+        "com.unity.multiplayer.tools": "1.1.0",
+        "com.unity.netcode.gameobjects": "1.4.0",
         "com.unity.services.relay": "1.0.3"
       },
-      "hash": "782ce810febe13fc4b68235389a0f3224b2418d2"
+      "hash": "0cd402eaea1969d4e9f894a5bc6c90432e12ab02"
     },
     "com.unity.multiplayer.tools": {
-      "version": "1.0.0",
-      "depth": 0,
+      "version": "1.1.0",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.profiling.core": "1.0.0-pre.1",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## [unreleased] - yyyy-mm-dd
+## [1.3.0] - 2023-07-07
 
 ### Dynamic Addressables Network Prefabs
 
@@ -18,6 +18,7 @@
 - Upgrade to Netcode for GameObjects 1.4.0 (#118)
 - Upgraded sample to 2021.3.24f1 LTS (#119)
 - Upgraded sample to 2022.3.0f1 LTS (#124)
+- Upgraded Samples Utilities version to v2.2.0 (#129)
 
 ### Client Driven
 
@@ -25,6 +26,7 @@
 - Upgrade to Netcode for GameObjects 1.4.0 (#118)
 - Upgraded sample to 2021.3.24f1 LTS (#119)
 - Upgraded sample to 2022.3.0f1 LTS (#124)
+- Upgraded Samples Utilities version to v2.2.0 (#129)
 
 ### Invaders
 
@@ -32,6 +34,7 @@
 - Upgrade to Netcode for GameObjects 1.4.0 (#118)
 - Upgraded sample to 2021.3.24f1 LTS (#119)
 - Upgraded sample to 2022.3.0f1 LTS (#124)
+- Upgraded Samples Utilities version to v2.2.0 (#129)
   
 #### Fixed
 - IP address input field text value is now passed into UTP's ConnectionData, allowing for remote IP address hosting (#112)


### PR DESCRIPTION
### Description
PR to upgrade all bitesize samples that were referencing Samples Utilities package to now point to a specific version, and will do so in the future.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
N/A
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for the project and/or any internal package
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ N/A ] JIRA ticket ID is in the PR title or at least one commit message
 - [ N/A ] Include the ticket ID number within the body message of the PR to create a hyperlink
