### PR TITLE
fix: DynamicAddressablesNetworkPrefabs showing loading status on already spawned prefabs [MTT-6688]

### DIFF
--- a/Basic/DynamicAddressablesNetworkPrefabs/Assets/Scripts/05_API Playground/APIPlayground.cs
+++ b/Basic/DynamicAddressablesNetworkPrefabs/Assets/Scripts/05_API Playground/APIPlayground.cs
@@ -337,7 +337,7 @@ namespace Game.APIPlayground
                     m_InGameUI.ClientLoadedPrefabStatusChanged(client, 
                         assetGuid.GetHashCode(), 
                         prefab.Result.name, 
-                        InGameUI.LoadStatus.Loading);
+                        InGameUI.LoadStatus.Loaded);
                 }
                 
                 return obj;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# Change log
+# Changelog
+
+## [unreleased] - yyyy-mm-dd
+
+### Dynamic Addressables Network Prefabs
+
+#### Fixed
+- Fixed loaded status displayed on UI for synchronous prefab spawns inside 05_API Playground Showcasing All Post-Connection Use-Cases scene (#132)
 
 ## [1.3.0] - 2023-07-07
 


### PR DESCRIPTION
### Description
This PR fixes the "Loading" state being displayed inside the API Playground scene when the host hits the Spawn 
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-6688](https://jira.unity3d.com/browse/MTT-6688)
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

Repro steps:
* Open scene 05_API Playground Showcasing All Post-Connection Use-Cases
* Hit play
* Host
* Hit Try Spawn Synchronously button
* Observe that the loading state of the loading prefab transitions from Loading to Loaded (this can happen quickly), but does not get stuck on Loading.

This was reproduceable on just the host, but testing the same steps with a ParrelSync client connected would be appreciated for sanity's sake.

### Contribution checklist
 - [ N/A ] Tests have been added for the project and/or any internal package
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
