### PR TITLE
fix: listening for NetworkObject parent changes to fix stuck ingredients on disconnects [MTT-7103]

### DIFF
--- a/Basic/ClientDriven/Assets/Prefabs/Ingredient.prefab
+++ b/Basic/ClientDriven/Assets/Prefabs/Ingredient.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 5818429371130516787}
   - component: {fileID: 5607146804455042385}
   - component: {fileID: 2549828380439460752}
+  - component: {fileID: -5120166168328346616}
   m_Layer: 6
   m_Name: Ingredient
   m_TagString: Untagged
@@ -30,6 +31,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8321201880322001125}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -11.03, y: 1.42, z: 7.558644}
   m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
@@ -41,7 +43,6 @@ Transform:
   - {fileID: 2558306008476788773}
   - {fileID: 7478805024049242977}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!135 &4840591773774142929
 SphereCollider:
@@ -152,6 +153,7 @@ MonoBehaviour:
   SynchronizeTransform: 1
   ActiveSceneSynchronization: 0
   SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1
 --- !u!114 &5607146804455042385
@@ -182,6 +184,20 @@ MonoBehaviour:
   m_BlueMaterial: {fileID: 2100000, guid: b423dced7a4ac4f40a119b84a23cfc9b, type: 2}
   m_RedMaterial: {fileID: 2100000, guid: d1a9058ddc5c2461298f65541af6fcd9, type: 2}
   m_ColorMesh: {fileID: 6206319821543937579}
+--- !u!114 &-5120166168328346616
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8321201880322001125}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18eacd80d71f7c948a562ba85d3618d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_NetworkTransform: {fileID: 2014424453305718345}
+  m_Rigidbody: {fileID: 7759258758774188825}
 --- !u!1001 &2596981318218469326
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Basic/ClientDriven/Assets/Scripts/ClientObjectWithIngredientType.cs
+++ b/Basic/ClientDriven/Assets/Scripts/ClientObjectWithIngredientType.cs
@@ -27,11 +27,19 @@ namespace Unity.Netcode.Samples
         {
             base.OnNetworkSpawn();
             enabled = IsClient;
+            
+            UpdateMaterial(default(IngredientType), m_Server.currentIngredientType.Value);
+            m_Server.currentIngredientType.OnValueChanged += UpdateMaterial;
         }
 
-        void UpdateMaterial()
+        public override void OnNetworkDespawn()
         {
-            switch (m_Server.currentIngredientType.Value)
+            m_Server.currentIngredientType.OnValueChanged -= UpdateMaterial;
+        }
+
+        void UpdateMaterial(IngredientType previousValue, IngredientType newValue)
+        {
+            switch (newValue)
             {
                 case IngredientType.Blue:
                     m_ColorMesh.material = m_BlueMaterial;
@@ -43,11 +51,6 @@ namespace Unity.Netcode.Samples
                     m_ColorMesh.material = m_PurpleMaterial;
                     break;
             }
-        }
-
-        protected void Update()
-        {
-            UpdateMaterial(); // this is not performant to be called every update, don't do this.
         }
     }
 }

--- a/Basic/ClientDriven/Assets/Scripts/ClientPlayerMove.cs
+++ b/Basic/ClientDriven/Assets/Scripts/ClientPlayerMove.cs
@@ -41,7 +41,7 @@ public class ClientPlayerMove : NetworkBehaviour
         // these two components disabled, and will enable a CapsuleCollider. Per the CharacterController documentation: 
         // https://docs.unity3d.com/Manual/CharacterControllers.html, a Character controller can push rigidbody
         // objects aside while moving but will not be accelerated by incoming collisions. This means that a primitive
-        // CapusleCollider must instead be used for ghost clients to simulate collisions between owning players and 
+        // CapsuleCollider must instead be used for ghost clients to simulate collisions between owning players and 
         // ghost clients.
         m_ThirdPersonController.enabled = false;
         m_CapsuleCollider.enabled = false;

--- a/Basic/ClientDriven/Assets/Scripts/ServerIngredientPhysics.cs
+++ b/Basic/ClientDriven/Assets/Scripts/ServerIngredientPhysics.cs
@@ -1,0 +1,26 @@
+using System;
+using Unity.Netcode;
+using Unity.Netcode.Components;
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class ServerIngredientPhysics : NetworkBehaviour
+{
+    [SerializeField]
+    NetworkTransform m_NetworkTransform;
+    
+    [SerializeField]
+    Rigidbody m_Rigidbody;
+    
+    public override void OnNetworkObjectParentChanged(NetworkObject parentNetworkObject)
+    {
+        SetPhysics(parentNetworkObject == null);
+    }
+
+    void SetPhysics(bool isEnabled)
+    {
+        m_Rigidbody.isKinematic = !isEnabled;
+        m_Rigidbody.interpolation = isEnabled ? RigidbodyInterpolation.Interpolate : RigidbodyInterpolation.None;
+        m_NetworkTransform.InLocalSpace = !isEnabled;
+    }
+}

--- a/Basic/ClientDriven/Assets/Scripts/ServerIngredientPhysics.cs.meta
+++ b/Basic/ClientDriven/Assets/Scripts/ServerIngredientPhysics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18eacd80d71f7c948a562ba85d3618d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basic/ClientDriven/Assets/Scripts/ServerPlayerMove.cs
+++ b/Basic/ClientDriven/Assets/Scripts/ServerPlayerMove.cs
@@ -56,14 +56,10 @@ public class ServerPlayerMove : NetworkBehaviour
 
         if (objectToPickup.TryGetComponent(out NetworkObject networkObject) && networkObject.TrySetParent(transform))
         {
-            var pickUpObjectRigidbody = objectToPickup.GetComponent<Rigidbody>();
-            pickUpObjectRigidbody.isKinematic = true;
-            pickUpObjectRigidbody.interpolation = RigidbodyInterpolation.None;
-            objectToPickup.GetComponent<NetworkTransform>().InLocalSpace = true;
+            m_PickedUpObject = networkObject;
             objectToPickup.transform.localPosition = m_LocalHeldPosition;
             objectToPickup.GetComponent<ServerIngredient>().ingredientDespawned += IngredientDespawned;
             isObjectPickedUp.Value = true;
-            m_PickedUpObject = objectToPickup;
         }
     }
 
@@ -78,12 +74,9 @@ public class ServerPlayerMove : NetworkBehaviour
     {
         if (m_PickedUpObject != null)
         {
+            m_PickedUpObject.GetComponent<ServerIngredient>().ingredientDespawned -= IngredientDespawned;
             // can be null if enter drop zone while carrying
             m_PickedUpObject.transform.parent = null;
-            var pickedUpObjectRigidbody = m_PickedUpObject.GetComponent<Rigidbody>();
-            pickedUpObjectRigidbody.isKinematic = false;
-            pickedUpObjectRigidbody.interpolation = RigidbodyInterpolation.Interpolate;
-            m_PickedUpObject.GetComponent<NetworkTransform>().InLocalSpace = false;
             m_PickedUpObject = null;
         }
 


### PR DESCRIPTION
### Description
PR to address stuck ingredients when clients disconnect. The drop and pickup RPCs have been refactored, and a new class to handle NetworkObject parent changes has been added to Ingredient prefabs.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### How to test
1. Have one instance host
2. Have another join host
3. Make client pick up an ingredient and afterwards disconnect
4. Ensure that the ball drops to the ground

### Issue Number(s)
[MTT-7103](https://jira.unity3d.com/browse/MTT-7103)
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for the project and/or any internal package
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
