### PR TITLE
fix: general fixes and client-side debug simulation tool fix

### DIFF
--- a/Basic/ClientDriven/Assets/Prefabs/Ingredient.prefab
+++ b/Basic/ClientDriven/Assets/Prefabs/Ingredient.prefab
@@ -11,9 +11,9 @@ GameObject:
   - component: {fileID: 4621998539424734916}
   - component: {fileID: 4840591773774142929}
   - component: {fileID: 7759258758774188825}
+  - component: {fileID: 5818429371130516787}
   - component: {fileID: 8268979759230423690}
   - component: {fileID: 2014424453305718345}
-  - component: {fileID: 5818429371130516787}
   - component: {fileID: 5607146804455042385}
   - component: {fileID: 2549828380439460752}
   - component: {fileID: -5120166168328346616}
@@ -92,6 +92,26 @@ Rigidbody:
   m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 3
+--- !u!114 &5818429371130516787
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8321201880322001125}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 3406890450
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 1
+  AutoObjectParentSync: 1
 --- !u!114 &8268979759230423690
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -136,26 +156,6 @@ MonoBehaviour:
   InLocalSpace: 0
   Interpolate: 1
   SlerpPosition: 0
---- !u!114 &5818429371130516787
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8321201880322001125}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
-  AlwaysReplicateAsRoot: 0
-  SynchronizeTransform: 1
-  ActiveSceneSynchronization: 0
-  SceneMigrationSynchronization: 1
-  SpawnWithObservers: 1
-  DontDestroyWithOwner: 0
-  AutoObjectParentSync: 1
 --- !u!114 &5607146804455042385
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Basic/ClientDriven/Assets/Prefabs/Ingredient.prefab
+++ b/Basic/ClientDriven/Assets/Prefabs/Ingredient.prefab
@@ -1,5 +1,41 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5916963673111665531
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2197807913315492384}
+  m_Layer: 0
+  m_Name: IngredientVisuals
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2197807913315492384
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5916963673111665531}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5073984626218265924}
+  - {fileID: 9198908101586070433}
+  - {fileID: 3824548929439723645}
+  - {fileID: 2558306008476788773}
+  - {fileID: 7478805024049242977}
+  m_Father: {fileID: 4621998539424734916}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8321201880322001125
 GameObject:
   m_ObjectHideFlags: 0
@@ -33,15 +69,11 @@ Transform:
   m_GameObject: {fileID: 8321201880322001125}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -11.03, y: 1.42, z: 7.558644}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5073984626218265924}
-  - {fileID: 9198908101586070433}
-  - {fileID: 3824548929439723645}
-  - {fileID: 2558306008476788773}
-  - {fileID: 7478805024049242977}
+  - {fileID: 2197807913315492384}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!135 &4840591773774142929
@@ -63,7 +95,7 @@ SphereCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Radius: 1
+  m_Radius: 0.75
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &7759258758774188825
 Rigidbody:
@@ -73,7 +105,7 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8321201880322001125}
   serializedVersion: 4
-  m_Mass: 1
+  m_Mass: 5
   m_Drag: 0
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
@@ -126,6 +158,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   currentIngredientType:
     m_InternalValue: 0
+  m_IngredientVisuals: {fileID: 5916963673111665531}
 --- !u!114 &2014424453305718345
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -144,12 +177,12 @@ MonoBehaviour:
   SyncRotAngleX: 1
   SyncRotAngleY: 1
   SyncRotAngleZ: 1
-  SyncScaleX: 0
-  SyncScaleY: 0
-  SyncScaleZ: 0
-  PositionThreshold: 0
-  RotAngleThreshold: 0
-  ScaleThreshold: 0
+  SyncScaleX: 1
+  SyncScaleY: 1
+  SyncScaleZ: 1
+  PositionThreshold: 0.001
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.01
   UseQuaternionSynchronization: 1
   UseQuaternionCompression: 1
   UseHalfFloatPrecision: 1
@@ -204,7 +237,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 4621998539424734916}
+    m_TransformParent: {fileID: 2197807913315492384}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_RootOrder
@@ -212,15 +245,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.0354737
+      value: 0.77660525
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.04605416
+      value: 0.03454062
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.0354737
+      value: 0.77660525
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -228,7 +261,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.003999982
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -240,7 +273,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalRotation.y
@@ -294,7 +327,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 4621998539424734916}
+    m_TransformParent: {fileID: 2197807913315492384}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_RootOrder
@@ -302,19 +335,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.65304524
+      value: 0.48978394
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.65304524
+      value: 0.48978394
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 0.65304524
+      value: 0.48978394
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.y
@@ -330,15 +363,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -384,7 +417,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 4621998539424734916}
+    m_TransformParent: {fileID: 2197807913315492384}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_RootOrder
@@ -392,19 +425,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.y
@@ -420,7 +453,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalRotation.y
@@ -471,7 +504,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 4621998539424734916}
+    m_TransformParent: {fileID: 2197807913315492384}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_RootOrder
@@ -479,23 +512,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.92373985
+      value: 0.6928049
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.05452756
+      value: 0.04089567
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 0.92373985
+      value: 0.6928049
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.005
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -507,7 +540,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalRotation.y
@@ -561,7 +594,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 4621998539424734916}
+    m_TransformParent: {fileID: 2197807913315492384}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_RootOrder
@@ -569,19 +602,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1
+      value: 0.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f7698f93880c2514a860d6ca1245a6a5, type: 3}
       propertyPath: m_LocalPosition.y

--- a/Basic/ClientDriven/Assets/Prefabs/PlayerArmature_Networked.prefab
+++ b/Basic/ClientDriven/Assets/Prefabs/PlayerArmature_Networked.prefab
@@ -1,5 +1,36 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3851650243920837590
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3078017941271782478}
+  m_Layer: 0
+  m_Name: IngredientHoldPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3078017941271782478
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3851650243920837590}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.443, z: 0.014567299}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7048647066491084048}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7567938585585123398
 GameObject:
   m_ObjectHideFlags: 0
@@ -25,13 +56,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7567938585585123398}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 303777381631976334}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!135 &6758041290174012784
 SphereCollider:
@@ -41,9 +72,17 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7567938585585123398}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 1
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Radius: 0.78
   m_Center: {x: 0, y: 0.78, z: 0}
 --- !u!114 &7639751301732027371
@@ -64,6 +103,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 3893294197879345259, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
@@ -153,6 +193,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 3893294197879345259, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
       insertIndex: -1
       addedObject: {fileID: 7602079168910818369}
+    - targetCorrespondingSourceObject: {fileID: 6044159111065775861, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
+      insertIndex: 0
+      addedObject: {fileID: 3078017941271782478}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 4416926081852918481, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
       insertIndex: -1
@@ -165,6 +208,9 @@ PrefabInstance:
       addedObject: {fileID: -2755784201116707001}
     - targetCorrespondingSourceObject: {fileID: 4416926081852918481, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
       insertIndex: -1
+      addedObject: {fileID: 4171929485582370989}
+    - targetCorrespondingSourceObject: {fileID: 4416926081852918481, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
+      insertIndex: -1
       addedObject: {fileID: 5667156634780145037}
     - targetCorrespondingSourceObject: {fileID: 4416926081852918481, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
       insertIndex: -1
@@ -172,9 +218,6 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 4416926081852918481, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
       insertIndex: -1
       addedObject: {fileID: 7243582772389402832}
-    - targetCorrespondingSourceObject: {fileID: 4416926081852918481, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4171929485582370989}
     - targetCorrespondingSourceObject: {fileID: 8187455079231382173, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
       insertIndex: -1
       addedObject: {fileID: 3615669438616969171}
@@ -197,8 +240,17 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1116025501350672692}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 0
+  serializedVersion: 2
   m_Radius: 0.28
   m_Height: 1.8
   m_Direction: 1
@@ -237,7 +289,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isObjectPickedUp:
     m_InternalValue: 0
-  m_LocalHeldPosition: {x: 0, y: 2.85, z: 0}
+  m_LocalHeldPosition: {x: 0, y: 0.5, z: 0}
+  IngredientHoldPosition: {fileID: 3851650243920837590}
+--- !u!114 &4171929485582370989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1116025501350672692}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03402a751b9a295458d2c001a73561e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &5667156634780145037
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -300,18 +365,6 @@ MonoBehaviour:
   InLocalSpace: 0
   Interpolate: 1
   SlerpPosition: 0
---- !u!114 &4171929485582370989
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1116025501350672692}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 03402a751b9a295458d2c001a73561e2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1116025501350672696 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4416926081852918493, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
@@ -364,5 +417,10 @@ MonoBehaviour:
 --- !u!95 &5969265393934875124 stripped
 Animator:
   m_CorrespondingSourceObject: {fileID: 6982812146204527121, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
+  m_PrefabInstance: {fileID: 3616664937583670245}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &7048647066491084048 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6044159111065775861, guid: 64dce48905ffd9b4293e595fa6941544, type: 3}
   m_PrefabInstance: {fileID: 3616664937583670245}
   m_PrefabAsset: {fileID: 0}

--- a/Basic/ClientDriven/Assets/Scenes/Bootstrap.unity
+++ b/Basic/ClientDriven/Assets/Scenes/Bootstrap.unity
@@ -3582,8 +3582,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2060465724}
-  - component: {fileID: 2060465723}
   - component: {fileID: 2060465722}
+  - component: {fileID: 2060465723}
   m_Layer: 0
   m_Name: IngredientSpawnPoints
   m_TagString: Untagged
@@ -3858,6 +3858,18 @@ PrefabInstance:
       propertyPath: GlobalObjectIdHash
       value: 15717686
       objectReference: {fileID: 0}
+    - target: {fileID: 5913527574646697333, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913527574646697333, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
+      propertyPath: m_Size.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913527574646697333, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
+      propertyPath: m_Size.z
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6114293678266807410, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
       propertyPath: GlobalObjectIdHash
       value: 2839102954
@@ -3869,6 +3881,14 @@ PrefabInstance:
     - target: {fileID: 6933559018710611339, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
       propertyPath: GlobalObjectIdHash
       value: 2439303291
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537118585589373863, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537118585589373863, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
+      propertyPath: m_Size.z
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7746496875028076563, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
       propertyPath: GlobalObjectIdHash

--- a/Basic/ClientDriven/Assets/Scenes/Bootstrap.unity
+++ b/Basic/ClientDriven/Assets/Scenes/Bootstrap.unity
@@ -154,7 +154,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 888605659}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
@@ -232,7 +231,6 @@ RectTransform:
   m_Children:
   - {fileID: 1958814325}
   m_Father: {fileID: 316760113}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -321,7 +319,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1366971298}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -478,7 +475,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 888605659}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -560,7 +556,6 @@ RectTransform:
   m_Children:
   - {fileID: 1366971298}
   m_Father: {fileID: 316760113}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -641,13 +636,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 232705322}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 14.58, y: 0.5, z: -13.27}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1980547847}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &316760112
 GameObject:
@@ -684,7 +679,6 @@ RectTransform:
   - {fileID: 1559167586}
   - {fileID: 125980622}
   m_Father: {fileID: 7616418622443165529}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -859,13 +853,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 406937058}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 10.37, y: 0.75, z: -10.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2060465724}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &474653826
 PrefabInstance:
@@ -971,13 +965,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 500839295}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 14.07, y: 0.5, z: 5.77}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1980547847}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &602928376
 PrefabInstance:
@@ -1095,7 +1089,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1002886974}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1170,7 +1163,6 @@ RectTransform:
   m_Children:
   - {fileID: 1372367860}
   m_Father: {fileID: 888605659}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1200,13 +1192,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 796975752}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -9.75, y: 0.75, z: 11.52}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2060465724}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &864671395
 GameObject:
@@ -1238,7 +1230,6 @@ RectTransform:
   m_Children:
   - {fileID: 965361483}
   m_Father: {fileID: 888605659}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
@@ -1372,7 +1363,6 @@ RectTransform:
   - {fileID: 753135933}
   - {fileID: 183508800}
   m_Father: {fileID: 1559167586}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1460,7 +1450,6 @@ RectTransform:
   m_Children:
   - {fileID: 1593829135}
   m_Father: {fileID: 1366971298}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1498,7 +1487,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 864671396}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1566,13 +1554,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 966089317}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &986711052 stripped
 GameObject:
@@ -1631,7 +1619,6 @@ RectTransform:
   m_Children:
   - {fileID: 699093859}
   m_Father: {fileID: 1958814325}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
@@ -1678,13 +1665,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1038740736}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1038740740
 MonoBehaviour:
@@ -1747,7 +1734,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1366971298}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
@@ -1881,13 +1867,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1114774665}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1217093268
 GameObject:
@@ -1920,7 +1906,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1958814325}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2079,13 +2064,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1265101692}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.32628977, y: 0.3580216, z: -0.13515317, w: 0.8643432}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 41.363, y: 45, z: 0}
 --- !u!1 &1299635453
 GameObject:
@@ -2144,13 +2129,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1299635453}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 10, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1335630871 stripped
 MonoBehaviour:
@@ -2197,7 +2182,6 @@ RectTransform:
   - {fileID: 960834599}
   - {fileID: 160840926}
   m_Father: {fileID: 231170286}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2374,7 +2358,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 753135933}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2450,7 +2433,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1913287522}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2518,13 +2500,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1422708175}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -7.09, y: 4.458488, z: -9.44}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2060465724}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1441907408
 GameObject:
@@ -2557,7 +2539,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1958814325}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
@@ -2633,7 +2614,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1621638975}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2711,7 +2691,6 @@ RectTransform:
   m_Children:
   - {fileID: 888605659}
   m_Father: {fileID: 316760113}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2800,7 +2779,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 960834599}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2875,7 +2853,6 @@ RectTransform:
   m_Children:
   - {fileID: 1482719292}
   m_Father: {fileID: 1366971298}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
@@ -2905,13 +2882,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1675346221}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -1.4, y: 0.75, z: 13.97}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2060465724}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1719355277
 PrefabInstance:
@@ -3029,13 +3006,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1773263766}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -2.91, y: 6.47, z: -15.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1980547847}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1826537006
 GameObject:
@@ -3076,6 +3053,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1826537006}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -3084,7 +3062,6 @@ Transform:
   - {fileID: 1997149794}
   - {fileID: 474653828}
   m_Father: {fileID: 0}
-  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1869134603
 PrefabInstance:
@@ -3262,7 +3239,6 @@ RectTransform:
   m_Children:
   - {fileID: 1401404383}
   m_Father: {fileID: 1958814325}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3303,7 +3279,6 @@ RectTransform:
   - {fileID: 1913287522}
   - {fileID: 1217093269}
   m_Father: {fileID: 125980622}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -3429,6 +3404,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1980547845}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -3439,7 +3415,6 @@ Transform:
   - {fileID: 1991538230}
   - {fileID: 1773263767}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1991538229
 GameObject:
@@ -3464,13 +3439,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1991538229}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -14.84, y: 0.5, z: -14.71}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1980547847}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1997149792
 PrefabInstance:
@@ -3590,13 +3565,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2051538844}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2060465721
 GameObject:
@@ -3643,7 +3618,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2060465721}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0e9fc72e2127848029b1e484d42a87db, type: 3}
   m_Name: 
@@ -3663,6 +3638,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2060465721}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -3673,7 +3649,6 @@ Transform:
   - {fileID: 1422708176}
   - {fileID: 796975753}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &330446109092541879
 PrefabInstance:
@@ -4054,7 +4029,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7616418622856753193}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4134,7 +4108,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7616418623250672375}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4211,7 +4184,6 @@ RectTransform:
   m_Children:
   - {fileID: 7616418622693132809}
   m_Father: {fileID: 7616418623250672375}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4291,7 +4263,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7616418622185726644}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4375,7 +4346,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7616418623252989437}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4415,7 +4385,6 @@ RectTransform:
   - {fileID: 7616418622856753193}
   - {fileID: 7616418621973298033}
   m_Father: {fileID: 7616418622323388917}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -4552,7 +4521,6 @@ RectTransform:
   - {fileID: 7616418622875608924}
   - {fileID: 7616418623250672375}
   m_Father: {fileID: 7616418622443165529}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4677,7 +4645,6 @@ RectTransform:
   - {fileID: 7616418623050433870}
   - {fileID: 7616418622323388917}
   m_Father: {fileID: 0}
-  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -4818,7 +4785,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7616418622632387608}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4858,7 +4824,6 @@ RectTransform:
   - {fileID: 7616418623547264601}
   - {fileID: 7616418622513569438}
   m_Father: {fileID: 7616418622323388917}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -4985,7 +4950,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7616418621877826181}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5062,7 +5026,6 @@ RectTransform:
   m_Children:
   - {fileID: 7616418621702260169}
   m_Father: {fileID: 7616418622185726644}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -5170,7 +5133,6 @@ RectTransform:
   - {fileID: 7616418623252989437}
   - {fileID: 7616418623720762617}
   m_Father: {fileID: 7616418622323388917}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -5237,7 +5199,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7616418623547264601}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5325,7 +5286,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7616418622443165529}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -5442,7 +5402,6 @@ RectTransform:
   - {fileID: 7616418621877826181}
   - {fileID: 7616418621730689109}
   m_Father: {fileID: 7616418622323388917}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -5501,7 +5460,6 @@ RectTransform:
   m_Children:
   - {fileID: 7616418622101976854}
   m_Father: {fileID: 7616418622875608924}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -5570,7 +5528,6 @@ RectTransform:
   m_Children:
   - {fileID: 7616418623021181525}
   m_Father: {fileID: 7616418622632387608}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -5650,7 +5607,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7616418622875608924}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5683,3 +5639,27 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7616418623720762618}
   m_CullTransparentMesh: 1
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1114774669}
+  - {fileID: 1038740739}
+  - {fileID: 2060465724}
+  - {fileID: 1980547847}
+  - {fileID: 1299635456}
+  - {fileID: 5723720766742547469}
+  - {fileID: 883084307}
+  - {fileID: 320533761}
+  - {fileID: 181529897}
+  - {fileID: 1719355277}
+  - {fileID: 1895732253}
+  - {fileID: 1869134603}
+  - {fileID: 966089318}
+  - {fileID: 330446109092541879}
+  - {fileID: 2051538846}
+  - {fileID: 1265101695}
+  - {fileID: 7616418622443165529}
+  - {fileID: 1826537008}
+  - {fileID: 602928376}
+  - {fileID: 1370077996}

--- a/Basic/ClientDriven/Assets/Scripts/DebugSimulationSlider.cs
+++ b/Basic/ClientDriven/Assets/Scripts/DebugSimulationSlider.cs
@@ -34,6 +34,8 @@ public class DebugSimulationSlider : MonoBehaviour
         m_NetworkManager = bootStrap.GetComponent<NetworkManager>();
         m_NetworkManager.OnServerStarted -= OnStarted;
         m_NetworkManager.OnServerStarted += OnStarted;
+        m_NetworkManager.OnClientStarted -= OnStarted;
+        m_NetworkManager.OnClientStarted += OnStarted;
         m_NetworkManager.OnClientStopped -= OnStopped;
         m_NetworkManager.OnServerStopped -= OnStopped;
         m_NetworkManager.OnClientStopped += OnStopped;

--- a/Basic/ClientDriven/Assets/Scripts/ServerIngredient.cs
+++ b/Basic/ClientDriven/Assets/Scripts/ServerIngredient.cs
@@ -60,19 +60,6 @@ public class ServerObjectWithIngredientType : NetworkBehaviour
 
         var serverPlayerMove = parentNetworkObject == null ? (ServerPlayerMove)null : parentNetworkObject.GetComponent<ServerPlayerMove>();
 
-        //if (IsServer)
-        //{
-        //    if (parentNetworkObject != null)
-        //    {
-        //        transform.localScale = m_OriginalScale * 0.25f;
-        //        transform.localPosition = serverPlayerMove.IngredientHoldPosition.transform.localPosition;
-        //    }
-        //    else
-        //    {
-        //        transform.localScale = m_OriginalScale;
-        //    }
-        //}
-
         if (m_IngredientVisuals != null)
         {
             if (parentNetworkObject != null)


### PR DESCRIPTION
### Description
Fixes several issues:
- Picking up now handles parenting slightly different where object is scaled and the visual is parented under a skeleton based GameObject.
- Tossing the ball now actually "tosses the ball".
- Debug simulation sliders no longer show up on clients when connected to a session.
- Other minor tweaks related to these adjustments.
- Updating the ingredient prefab and fixing an issue with player despawning server-side with ingredient still being held.


### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
