### PR TITLE
fix: remove unnecessary NetworkVariable in 2DSpaceShooter

### DIFF
--- a/Basic/2DSpaceShooter/Assets/Prefabs/Ship.prefab
+++ b/Basic/2DSpaceShooter/Assets/Prefabs/Ship.prefab
@@ -11,10 +11,10 @@ GameObject:
   - component: {fileID: 400000}
   - component: {fileID: 5000000}
   - component: {fileID: 5800000}
+  - component: {fileID: 509584576524893815}
   - component: {fileID: 11400004}
   - component: {fileID: 8200000}
   - component: {fileID: 8200002}
-  - component: {fileID: 509584576524893815}
   - component: {fileID: -360930162699739946}
   - component: {fileID: -8406883944196582507}
   - component: {fileID: 7896695181562740567}
@@ -33,6 +33,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100000}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 16.686096, y: -1.5172029, z: 0}
   m_LocalScale: {x: 0.6, y: 0.6, z: 0.6}
@@ -41,7 +42,6 @@ Transform:
   - {fileID: 400004}
   - {fileID: 1255143139002862940}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &5000000
 Rigidbody2D:
@@ -105,6 +105,26 @@ CircleCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Radius: 0.64
+--- !u!114 &509584576524893815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 4192032552
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
 --- !u!114 &11400004
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -173,7 +193,7 @@ MonoBehaviour:
         byte0028: 0
         byte0029: 0
   m_Friction: {fileID: 19800002}
-  m_Thrust: {fileID: 19800000}
+  m_ThrustParticleSystem: {fileID: 19800000}
   m_ShipGlow: {fileID: 5983711199006031825}
   m_ShipGlowDefaultColor: {r: 1, g: 1, b: 1, a: 1}
   m_UIDocument: {fileID: 7896695181562740567}
@@ -370,25 +390,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!114 &509584576524893815
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 100000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
-  AlwaysReplicateAsRoot: 0
-  SynchronizeTransform: 1
-  ActiveSceneSynchronization: 0
-  SceneMigrationSynchronization: 1
-  DontDestroyWithOwner: 0
-  AutoObjectParentSync: 1
 --- !u!114 &-360930162699739946
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -485,13 +486,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100002}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.70710284, y: 0.0023588336, z: -0.70710295, w: 0.0023588329}
   m_LocalPosition: {x: -1.73, y: 0.05, z: 0.46}
   m_LocalScale: {x: 1.26, y: 1.26, z: 1.26}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1255143139002862940}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!198 &19800000
 ParticleSystem:
@@ -5287,13 +5288,15 @@ ParticleSystemRenderer:
   m_RenderAlignment: 0
   m_Pivot: {x: 0, y: 0, z: 0}
   m_Flip: {x: 0, y: 0, z: 0}
-  m_UseCustomVertexStreams: 0
   m_EnableGPUInstancing: 0
   m_ApplyActiveColorSpace: 0
   m_AllowRoll: 1
   m_FreeformStretching: 0
   m_RotateWithStretchDirection: 1
+  m_UseCustomVertexStreams: 0
   m_VertexStreams: 0001030405
+  m_UseCustomTrailVertexStreams: 0
+  m_TrailVertexStreams: 00010304
   m_Mesh: {fileID: 0}
   m_Mesh1: {fileID: 0}
   m_Mesh2: {fileID: 0}
@@ -5328,13 +5331,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100004}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 1, z: 0, w: -0}
   m_LocalPosition: {x: 0.45, y: -0.019937, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 400000}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!198 &19800002
 ParticleSystem:
@@ -10130,13 +10133,15 @@ ParticleSystemRenderer:
   m_RenderAlignment: 0
   m_Pivot: {x: 0, y: 0, z: 0}
   m_Flip: {x: 0, y: 0, z: 0}
-  m_UseCustomVertexStreams: 0
   m_EnableGPUInstancing: 0
   m_ApplyActiveColorSpace: 0
   m_AllowRoll: 1
   m_FreeformStretching: 0
   m_RotateWithStretchDirection: 1
+  m_UseCustomVertexStreams: 0
   m_VertexStreams: 0001030405
+  m_UseCustomTrailVertexStreams: 0
+  m_TrailVertexStreams: 00010304
   m_Mesh: {fileID: 0}
   m_Mesh1: {fileID: 0}
   m_Mesh2: {fileID: 0}
@@ -10170,6 +10175,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4711364113217113794}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.27, y: 0, z: 0}
   m_LocalScale: {x: 0.3890193, y: 0.3890193, z: 0.3890193}
@@ -10178,7 +10184,6 @@ Transform:
   - {fileID: 389295837323142884}
   - {fileID: 400002}
   m_Father: {fileID: 400000}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &3390849995755675818
 SpriteRenderer:
@@ -10256,13 +10261,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6021497113750022543}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0.07}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1255143139002862940}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &5983711199006031825
 SpriteRenderer:

--- a/Basic/2DSpaceShooter/Assets/Scripts/ShipControl.cs
+++ b/Basic/2DSpaceShooter/Assets/Scripts/ShipControl.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Unity.Collections;
+﻿using Unity.Collections;
 using Unity.Netcode;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -74,7 +73,7 @@ public class ShipControl : NetworkBehaviour
     ParticleSystem m_Friction;
     
     [SerializeField] 
-    ParticleSystem m_Thrust;
+    ParticleSystem m_ThrustParticleSystem;
     
     [SerializeField] 
     SpriteRenderer m_ShipGlow;
@@ -107,7 +106,7 @@ public class ShipControl : NetworkBehaviour
     float m_OldSpin = 0;
 
     // server movement
-    float m_Thrusting;
+    float m_Thrust;
 
     float m_Spin;
 
@@ -119,7 +118,7 @@ public class ShipControl : NetworkBehaviour
         m_ObjectPool = GameObject.FindWithTag(s_ObjectPoolTag).GetComponent<NetworkObjectPool>();
         Assert.IsNotNull(m_ObjectPool, $"{nameof(NetworkObjectPool)} not found in scene. Did you apply the {s_ObjectPoolTag} to the GameObject?");
         
-        m_ThrustMain = m_Thrust.main;
+        m_ThrustMain = m_ThrustParticleSystem.main;
         m_ShipGlow.color = m_ShipGlowDefaultColor;
         m_IsBuffed = false;
         
@@ -271,7 +270,7 @@ public class ShipControl : NetworkBehaviour
         m_Rigidbody2D.angularVelocity = rotate;
 
         // update thrust
-        if (m_Thrusting != 0)
+        if (m_Thrust != 0)
         {
             float accel = m_Acceleration;
             if (SpeedBuffTimer.Value > NetworkManager.ServerTime.TimeAsFloat)
@@ -279,7 +278,7 @@ public class ShipControl : NetworkBehaviour
                 accel *= 2;
             }
 
-            Vector3 thrustVec = transform.right * (m_Thrusting * accel);
+            Vector3 thrustVec = transform.right * (m_Thrust * accel);
             m_Rigidbody2D.AddForce(thrustVec);
 
             // restrict max speed
@@ -504,7 +503,7 @@ public class ShipControl : NetworkBehaviour
     [ServerRpc]
     public void ThrustServerRpc(float thrusting, int spin)
     {
-        m_Thrusting = thrusting;
+        m_Thrust = thrusting;
         m_Spin = spin;
     }
 

--- a/Basic/2DSpaceShooter/Assets/Scripts/ShipControl.cs
+++ b/Basic/2DSpaceShooter/Assets/Scripts/ShipControl.cs
@@ -107,7 +107,7 @@ public class ShipControl : NetworkBehaviour
     float m_OldSpin = 0;
 
     // server movement
-    private NetworkVariable<float> m_Thrusting = new NetworkVariable<float>();
+    float m_Thrusting;
 
     float m_Spin;
 
@@ -271,7 +271,7 @@ public class ShipControl : NetworkBehaviour
         m_Rigidbody2D.angularVelocity = rotate;
 
         // update thrust
-        if (m_Thrusting.Value != 0)
+        if (m_Thrusting != 0)
         {
             float accel = m_Acceleration;
             if (SpeedBuffTimer.Value > NetworkManager.ServerTime.TimeAsFloat)
@@ -279,7 +279,7 @@ public class ShipControl : NetworkBehaviour
                 accel *= 2;
             }
 
-            Vector3 thrustVec = transform.right * (m_Thrusting.Value * accel);
+            Vector3 thrustVec = transform.right * (m_Thrusting * accel);
             m_Rigidbody2D.AddForce(thrustVec);
 
             // restrict max speed
@@ -504,7 +504,7 @@ public class ShipControl : NetworkBehaviour
     [ServerRpc]
     public void ThrustServerRpc(float thrusting, int spin)
     {
-        m_Thrusting.Value = thrusting;
+        m_Thrusting = thrusting;
         m_Spin = spin;
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Upgraded to Netcode for GameObjects v1.7.1 (#147)
 - Upgraded sample to 2022.3.14f1 LTS (#147)
 
+### Fixes
+- Converted unnecessary ship thrust NetworkVariable to a float (#149)
+
 ### Client Driven
 
 #### Changed


### PR DESCRIPTION
### Description
Addressing the issue [here](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.bitesize/issues/128).
This PR removes an unnecessary NetworkVariable from 2DSpaceShooter.
Benefit: reducing network bandwidth used to sync variable to clients.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
Original [issue](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.bitesize/issues/128).
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for the project and/or any internal package
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ N/A ] JIRA ticket ID is in the PR title or at least one commit message
 - [ N/A ] Include the ticket ID number within the body message of the PR to create a hyperlink
