### PR TITLE
fix: correct variable names used for initialization (external PR #145)

### DIFF
--- a/Basic/2DSpaceShooter/Assets/Scripts/ShipControl.cs
+++ b/Basic/2DSpaceShooter/Assets/Scripts/ShipControl.cs
@@ -152,8 +152,8 @@ public class ShipControl : NetworkBehaviour
         }
         Energy.OnValueChanged += OnEnergyChanged;
         Health.OnValueChanged += OnHealthChanged;
-        OnEnergyChanged(0, Health.Value);
-        OnHealthChanged(0, Energy.Value);
+        OnEnergyChanged(0, Energy.Value);
+        OnHealthChanged(0, Health.Value);
         
         SetPlayerName(PlayerName.Value.ToString().ToUpper());
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Upgraded to Netcode for GameObjects v1.7.1 (#147)
 - Upgraded sample to 2022.3.14f1 LTS (#147)
 
+### Fixed
+- Corrected the variables used for initialization of Health and Energy (#150)
+
 ### Client Driven
 
 #### Changed


### PR DESCRIPTION
### Description
This is an internal PR that brings along the fix completed in this external PR.
Yamato jobs won't trigger from external PRs, so this is a temporary solution to ensure jobs run on external work.

Here, variable names are swapped for proper initialization.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
N/A. Original PR: #145 
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for the project and/or any internal package
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ N/A ] JIRA ticket ID is in the PR title or at least one commit message
 - [ N/A ] Include the ticket ID number within the body message of the PR to create a hyperlink
