### PR TITLE
Fix: Client Driven Ghost Static Ingredients on Late join [MTT-4505]

### DIFF
--- a/Basic/ClientDriven/Assets/Prefabs/ObjectSpawner.prefab
+++ b/Basic/ClientDriven/Assets/Prefabs/ObjectSpawner.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &536145635693947214
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 207166779390499285}
+  - component: {fileID: 1695740223341187737}
+  m_Layer: 0
+  m_Name: ObjectSpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &207166779390499285
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 536145635693947214}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1695740223341187737
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 536145635693947214}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a358fd16b205c224fae652283f7cedae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prefabReference: {fileID: 5818429371130516787, guid: a6b33b41508134c09957e076f4d53415, type: 3}

--- a/Basic/ClientDriven/Assets/Prefabs/ObjectSpawner.prefab.meta
+++ b/Basic/ClientDriven/Assets/Prefabs/ObjectSpawner.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 34c1add8edaf6e44787b5c1a6803a83e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basic/ClientDriven/Assets/Scenes/Bootstrap.unity
+++ b/Basic/ClientDriven/Assets/Scenes/Bootstrap.unity
@@ -123,7 +123,7 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &181529897
+--- !u!1001 &232086523
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -131,75 +131,83 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 7.19
+      value: 3.03
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.42
+      value: 1.58
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 2.05
+      value: 5.24
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5818429371130516787, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 588047825
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: CurrentIngredientType
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: CurrentIngredientType.m_InternalValue
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: currentIngredientType.m_InternalValue
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8321201880322001125, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_Name
-      value: Ingredient (3)
+      value: ObjectSpawner (3)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      insertIndex: 1
+      addedObject: {fileID: 232086525}
+  m_SourcePrefab: {fileID: 100100000, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+--- !u!1 &232086524 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+  m_PrefabInstance: {fileID: 232086523}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &232086525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 232086524}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 2945538600
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 1
+  SceneMigrationSynchronization: 0
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
 --- !u!1 &232705322
 GameObject:
   m_ObjectHideFlags: 0
@@ -231,87 +239,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1980547847}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &320533761
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -6.93
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -14.16
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4644362981357575575, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: d1a9058ddc5c2461298f65541af6fcd9, type: 2}
-    - target: {fileID: 5818429371130516787, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 1277636585
-      objectReference: {fileID: 0}
-    - target: {fileID: 6206319821543937579, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: d1a9058ddc5c2461298f65541af6fcd9, type: 2}
-    - target: {fileID: 6691487417621146171, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: d1a9058ddc5c2461298f65541af6fcd9, type: 2}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: currentIngredientType
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8321201880322001125, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Name
-      value: Ingredient (2)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a6b33b41508134c09957e076f4d53415, type: 3}
 --- !u!1 &406937058
 GameObject:
   m_ObjectHideFlags: 0
@@ -532,6 +459,116 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f6d148d888ffbf54b9afe9936dfaec1f, type: 3}
+--- !u!1001 &666714754
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.58
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_Name
+      value: ObjectSpawner (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      insertIndex: 1
+      addedObject: {fileID: 666714756}
+  m_SourcePrefab: {fileID: 100100000, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+--- !u!1 &666714755 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+  m_PrefabInstance: {fileID: 666714754}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &666714756
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 666714755}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 2336653778
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 1
+  SceneMigrationSynchronization: 0
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+--- !u!1 &765414554 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+  m_PrefabInstance: {fileID: 2255677428018747830}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &765414557
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 765414554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 2969950326
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 1
+  SceneMigrationSynchronization: 0
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
 --- !u!1 &796975752
 GameObject:
   m_ObjectHideFlags: 0
@@ -563,99 +600,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 2060465724}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &883084307
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -10.82
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 13.44
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4644362981357575575, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: b423dced7a4ac4f40a119b84a23cfc9b, type: 2}
-    - target: {fileID: 5818429371130516787, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 2015703404
-      objectReference: {fileID: 0}
-    - target: {fileID: 6206319821543937579, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: b423dced7a4ac4f40a119b84a23cfc9b, type: 2}
-    - target: {fileID: 6691487417621146171, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: b423dced7a4ac4f40a119b84a23cfc9b, type: 2}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: CurrentIngredientType
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: currentIngredientType
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: CurrentIngredientType.m_InternalValue
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: currentIngredientType.m_InternalValue
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8321201880322001125, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Name
-      value: Ingredient (1)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a6b33b41508134c09957e076f4d53415, type: 3}
 --- !u!1 &966089317
 GameObject:
   m_ObjectHideFlags: 0
@@ -1222,99 +1166,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 2060465724}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1719355277
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_RootOrder
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.61
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10.04
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4644362981357575575, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: b423dced7a4ac4f40a119b84a23cfc9b, type: 2}
-    - target: {fileID: 5818429371130516787, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 1167607349
-      objectReference: {fileID: 0}
-    - target: {fileID: 6206319821543937579, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: b423dced7a4ac4f40a119b84a23cfc9b, type: 2}
-    - target: {fileID: 6691487417621146171, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: b423dced7a4ac4f40a119b84a23cfc9b, type: 2}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: CurrentIngredientType
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: currentIngredientType
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: CurrentIngredientType.m_InternalValue
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: currentIngredientType.m_InternalValue
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8321201880322001125, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Name
-      value: Ingredient (4)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a6b33b41508134c09957e076f4d53415, type: 3}
 --- !u!1 &1773263766
 GameObject:
   m_ObjectHideFlags: 0
@@ -1394,152 +1245,6 @@ Transform:
   - {fileID: 474653828}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1869134603
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_RootOrder
-      value: 11
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 12.44
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -10.44
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 43.354
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -56.524
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 66.302
-      objectReference: {fileID: 0}
-    - target: {fileID: 5818429371130516787, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 2317574502
-      objectReference: {fileID: 0}
-    - target: {fileID: 6206319821543937579, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: d1a9058ddc5c2461298f65541af6fcd9, type: 2}
-    - target: {fileID: 6691487417621146171, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6691487417621146171, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: d1a9058ddc5c2461298f65541af6fcd9, type: 2}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: currentIngredientType
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8321201880322001125, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Name
-      value: Ingredient (6)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a6b33b41508134c09957e076f4d53415, type: 3}
---- !u!1001 &1895732253
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_RootOrder
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 14.26
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -7.03
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4644362981357575575, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: d1a9058ddc5c2461298f65541af6fcd9, type: 2}
-    - target: {fileID: 5818429371130516787, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 1282886573
-      objectReference: {fileID: 0}
-    - target: {fileID: 6206319821543937579, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: d1a9058ddc5c2461298f65541af6fcd9, type: 2}
-    - target: {fileID: 6691487417621146171, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: d1a9058ddc5c2461298f65541af6fcd9, type: 2}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: currentIngredientType
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8321201880322001125, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_Name
-      value: Ingredient (5)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a6b33b41508134c09957e076f4d53415, type: 3}
 --- !u!1 &1971400596 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2182991878644361159, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
@@ -1728,6 +1433,91 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3608989045728912046, guid: 2cb44b699415ff447a63b3c87e56fd16, type: 3}
   m_PrefabInstance: {fileID: 1997149792}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2024285500
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.58
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      propertyPath: m_Name
+      value: ObjectSpawner (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      insertIndex: 1
+      addedObject: {fileID: 2024285502}
+  m_SourcePrefab: {fileID: 100100000, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+--- !u!1 &2024285501 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+  m_PrefabInstance: {fileID: 2024285500}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2024285502
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2024285501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 3035510238
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 1
+  SceneMigrationSynchronization: 0
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
 --- !u!1 &2051538844
 GameObject:
   m_ObjectHideFlags: 0
@@ -2108,7 +1898,7 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 1368949947}
   m_SourcePrefab: {fileID: 100100000, guid: d793abe7ff9aa094eb534e73a82fdab5, type: 3}
---- !u!1001 &5723720766742547469
+--- !u!1001 &2255677428018747830
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -2116,80 +1906,58 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -14.38
+      value: 3.62
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.42
+      value: 1.58
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 11.72
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4621998539424734916, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 207166779390499285, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5818429371130516787, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 2123788497
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: CurrentIngredientType
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: m_StartingIngredientType
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: CurrentIngredientType.m_InternalValue
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8268979759230423690, guid: a6b33b41508134c09957e076f4d53415, type: 3}
-      propertyPath: currentIngredientType.m_InternalValue
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8321201880322001125, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    - target: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
       propertyPath: m_Name
-      value: Ingredient
+      value: ObjectSpawner
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 1702713463106468697, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a6b33b41508134c09957e076f4d53415, type: 3}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 536145635693947214, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
+      insertIndex: 1
+      addedObject: {fileID: 765414557}
+  m_SourcePrefab: {fileID: 100100000, guid: 34c1add8edaf6e44787b5c1a6803a83e, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -2199,13 +1967,6 @@ SceneRoots:
   - {fileID: 2060465724}
   - {fileID: 1980547847}
   - {fileID: 1299635456}
-  - {fileID: 5723720766742547469}
-  - {fileID: 883084307}
-  - {fileID: 320533761}
-  - {fileID: 181529897}
-  - {fileID: 1719355277}
-  - {fileID: 1895732253}
-  - {fileID: 1869134603}
   - {fileID: 966089318}
   - {fileID: 330446109092541879}
   - {fileID: 2051538846}
@@ -2213,3 +1974,7 @@ SceneRoots:
   - {fileID: 1826537008}
   - {fileID: 602928376}
   - {fileID: 1370077996}
+  - {fileID: 2255677428018747830}
+  - {fileID: 666714754}
+  - {fileID: 2024285500}
+  - {fileID: 232086523}

--- a/Basic/ClientDriven/Assets/Scripts/NetworkObjectSpawner.cs
+++ b/Basic/ClientDriven/Assets/Scripts/NetworkObjectSpawner.cs
@@ -1,0 +1,30 @@
+using System;
+using Unity.Netcode;
+using UnityEngine;
+using UnityEngine.Networking;
+using Random = System.Random;
+
+public class NetworkObjectSpawner : NetworkBehaviour
+{
+    public NetworkObject prefabReference;
+    Random m_RandomGenerator = new Random();
+
+    public override void OnNetworkSpawn()
+    {
+        base.OnNetworkSpawn();
+        if (!IsServer)
+        {
+            enabled = false;
+            return;
+        }
+
+        if (IsServer)
+        {
+            var instantiatedNetworkObject = Instantiate(prefabReference, transform.position, transform.rotation, null);
+            var ingredient = instantiatedNetworkObject.GetComponent<ServerIngredient>();
+            ingredient.NetworkObject.Spawn();
+            ingredient.currentIngredientType.Value = (IngredientType)m_RandomGenerator.Next((int)IngredientType.MAX);
+            enabled = false;
+        }
+    }
+}

--- a/Basic/ClientDriven/Assets/Scripts/NetworkObjectSpawner.cs.meta
+++ b/Basic/ClientDriven/Assets/Scripts/NetworkObjectSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a358fd16b205c224fae652283f7cedae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->
To remove the inconsistent behavior for late joiners (ingredients existing on late joiners side even though they were removed by another player) the in-scene placed objects got removed and spawners similar to the ones in Boss Room got added to achieve consistent behavior between clients 

How to test:

1. Open Client Driven Sample
2. Create a build or clone
3. Join as host and bring one ingredient to goal with host
4. Late-join from other build/editor and check that scene looks identical for both players

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

[MTT-4505](https://jira.unity3d.com/browse/MTT-4505)

### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
