### PR TITLE
Use slough artifactory in CI Part 2

### DIFF
--- a/.yamato/tests.yml
+++ b/.yamato/tests.yml
@@ -16,7 +16,7 @@ test_{{ project.name }}_{{ editor }}_{{ platform.name }}:
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -u {{ editor }} -c editor -w --fast
 {% if platform.name == "win" -%} #windows
-    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+    - curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
 {% if project.run_editor_tests -%} # Only run editor tests for projects where relevant
     - utr --suite=editor --editor-location=.Editor --testproject={{ project.path }} --testfilter={{ project.test_filter }} --artifacts-path=testlogs
 {% endif -%}
@@ -24,7 +24,7 @@ test_{{ project.name }}_{{ editor }}_{{ platform.name }}:
     - utr --suite=playmode --editor-location=.Editor --testproject={{ project.path }} --testfilter={{ project.test_filter }} --artifacts-path=testlogs
 {% endif -%}
 {% else -%}
-    - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+    - curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
     - chmod +x utr
 {% if project.run_editor_tests -%} # Only run editor tests for projects where relevant
     - ./utr --suite=editor --editor-location=.Editor --testproject={{ project.path }} --testfilter={{ project.test_filter }} --artifacts-path=testlogs


### PR DESCRIPTION
There's an ongoing incident in [#incident-2024-03-25-1](https://unity.enterprise.slack.com/archives/C06R0T5V18E) that is causing timeouts for IT Artifactory. 

This PR is part of a series of updates where we try to reduce the load on artifactory as well as lowering the risk of Yamato jobs timing out by relying on it less.

Slough artifactory is useful because it is an artifactory instance in the same datacenter as the vms the Yamato jobs run on.


This PR specifically addresses:
* UTR script downloads from IT artifactory have been replaced with slough artifactory.


This PR is auto generated so the results is probably pretty dumb. 


If something looks strange then please help it along by correcting anything that is incorrect or missing.

[_Created by Sourcegraph batch change `henrikp/utr-slough-artifactory`._](https://sourcegraph.ds.unity3d.com/users/henrikp/batch-changes/utr-slough-artifactory)