### PR TITLE
Fix: Adding comments on ingredients parenting to make it clear what is being done [MTT-8377]

### DIFF
--- a/Basic/ClientDriven/Assets/Scripts/ServerIngredientPhysics.cs
+++ b/Basic/ClientDriven/Assets/Scripts/ServerIngredientPhysics.cs
@@ -1,4 +1,3 @@
-using System;
 using Unity.Netcode;
 using Unity.Netcode.Components;
 using UnityEngine;
@@ -14,13 +13,24 @@ public class ServerIngredientPhysics : NetworkBehaviour
 
     public override void OnNetworkObjectParentChanged(NetworkObject parentNetworkObject)
     {
-        SetPhysics(parentNetworkObject == null);
-    }
-
-    void SetPhysics(bool isEnabled)
-    {
-        m_Rigidbody.isKinematic = !isEnabled;
-        m_Rigidbody.interpolation = isEnabled ? RigidbodyInterpolation.Interpolate : RigidbodyInterpolation.None;
-        m_NetworkTransform.InLocalSpace = !isEnabled;
+        // The physic needs to be disabled when the ingredient is parented so that it's following the parent instead of moving freely.
+        if (parentNetworkObject != null)
+        {
+            // Setting isKinematic to true will prevent the object from being affected by the physic in the game,
+            // which will let it follow the parented player and not being bumped around by other rigidbodies.
+            m_Rigidbody.isKinematic = true;
+            // Rigibodies in Unity ignore parenting when updating their transform position.
+            // Changing the interpolation to None when a Kinematic rigibody is the child of another rigidbody
+            // will allow the object to keep the same local position.
+            m_Rigidbody.interpolation = RigidbodyInterpolation.None;
+            m_NetworkTransform.InLocalSpace = true;
+        }
+        // If the ingredient is not parented anymore, the physic is turned back on.
+        else
+        {
+            m_Rigidbody.isKinematic = false;
+            m_Rigidbody.interpolation = RigidbodyInterpolation.Interpolate;
+            m_NetworkTransform.InLocalSpace = false;
+        }
     }
 }

--- a/Basic/ClientDriven/Assets/Scripts/ServerIngredientPhysics.cs
+++ b/Basic/ClientDriven/Assets/Scripts/ServerIngredientPhysics.cs
@@ -13,24 +13,18 @@ public class ServerIngredientPhysics : NetworkBehaviour
 
     public override void OnNetworkObjectParentChanged(NetworkObject parentNetworkObject)
     {
-        // The physic needs to be disabled when the ingredient is parented so that it's following the parent instead of moving freely.
-        if (parentNetworkObject != null)
-        {
-            // Setting isKinematic to true will prevent the object from being affected by the physic in the game,
-            // which will let it follow the parented player and not being bumped around by other rigidbodies.
-            m_Rigidbody.isKinematic = true;
-            // Rigibodies in Unity ignore parenting when updating their transform position.
-            // Changing the interpolation to None when a Kinematic rigibody is the child of another rigidbody
-            // will allow the object to keep the same local position.
-            m_Rigidbody.interpolation = RigidbodyInterpolation.None;
-            m_NetworkTransform.InLocalSpace = true;
-        }
-        // If the ingredient is not parented anymore, the physic is turned back on.
-        else
-        {
-            m_Rigidbody.isKinematic = false;
-            m_Rigidbody.interpolation = RigidbodyInterpolation.Interpolate;
-            m_NetworkTransform.InLocalSpace = false;
-        }
+        // The ingredient's physic needs to be disabled when the ingredient is parented so that it's following the parent instead of moving freely.
+        SetKinematic(parentNetworkObject != null);
+    }
+
+    private void SetKinematic(bool isEnabled)
+    {
+        // Setting isKinematic to true will prevent the object from being affected by the physic forces in the game.
+        m_Rigidbody.isKinematic = isEnabled;
+        // When parented, rigidbody children are only moving because they receive their parent forces along with their own physic.
+        // When kinematic is true, they will ignore their parent forces and stay at the same world place.
+        // Changing the interpolation to None in that case will allow the object to keep the same local position instead of the world position.
+        m_Rigidbody.interpolation = isEnabled ? RigidbodyInterpolation.None : RigidbodyInterpolation.Interpolate;
+        m_NetworkTransform.InLocalSpace = isEnabled;
     }
 }


### PR DESCRIPTION
### Description
This PR removes the SetPhysics method from ServerIngredientPhysics and is adding comments to the changes made to the Rigidbody variables to make the intent easier to understand.

### Issue Number(s)
[MTT-8377](https://jira.unity3d.com/browse/MTT-8377) Adding a comment on why Rigidbody.interpolation need to be changed on kinematic objects when parenting them.

### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
