### PR TITLE
Upgrade Invaders to use Netcode For Gameobject 1.8.1 [MTT-8503]

### DIFF
--- a/Basic/Invaders/Assets/Prefabs/Invaders Game Manager.prefab
+++ b/Basic/Invaders/Assets/Prefabs/Invaders Game Manager.prefab
@@ -9,8 +9,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4266113290039088506}
-  - component: {fileID: 4266113290039088507}
   - component: {fileID: 2756959678467573149}
+  - component: {fileID: 4266113290039088507}
   m_Layer: 0
   m_Name: Invaders Game Manager
   m_TagString: Untagged
@@ -25,42 +25,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4266113290039088508}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4266113290039088507
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4266113290039088508}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d643b609c6a71c54984c1ad454faa28b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  enemy1Prefab: {fileID: 100000, guid: 43ae6ad1bdadd0747811bb7a00740c2c, type: 3}
-  enemy2Prefab: {fileID: 100000, guid: 38a8441efb2d6d245adbf08f08705374, type: 3}
-  enemy3Prefab: {fileID: 100000, guid: aa50d36274d0dfc4faff2c69820b3711, type: 3}
-  superEnemyPrefab: {fileID: 100000, guid: e811e4fb062e31444aaf36dbec5de77c, type: 3}
-  shieldPrefab: {fileID: 100000, guid: b990a6e6dcf54b646a7397028fed6045, type: 3}
-  gameTimerText: {fileID: 0}
-  scoreText: {fileID: 0}
-  livesText: {fileID: 0}
-  gameOverText: {fileID: 0}
-  saucerSpawnPoint: {fileID: 0}
-  m_DelayedStartTime: 5
-  m_TickPeriodic:
-    m_InternalValue: 0.2
-  m_EnemyMovingDirection:
-    m_InternalValue: 0.3
-  m_RandomThresholdForSaucerCreation: 0.92
 --- !u!114 &2756959678467573149
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -73,7 +45,45 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
+  GlobalObjectIdHash: 2783302607
+  InScenePlacedSourceGlobalObjectIdHash: 0
   AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1
+--- !u!114 &4266113290039088507
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4266113290039088508}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d643b609c6a71c54984c1ad454faa28b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemy1Prefab: {fileID: 2037077820506562951, guid: 43ae6ad1bdadd0747811bb7a00740c2c,
+    type: 3}
+  enemy2Prefab: {fileID: 1361474663871475650, guid: 38a8441efb2d6d245adbf08f08705374,
+    type: 3}
+  enemy3Prefab: {fileID: 7651551376209856180, guid: aa50d36274d0dfc4faff2c69820b3711,
+    type: 3}
+  superEnemyPrefab: {fileID: 3955316467729786863, guid: e811e4fb062e31444aaf36dbec5de77c,
+    type: 3}
+  shieldPrefab: {fileID: 6564576217164106930, guid: b990a6e6dcf54b646a7397028fed6045,
+    type: 3}
+  gameTimerText: {fileID: 0}
+  scoreText: {fileID: 0}
+  livesText: {fileID: 0}
+  gameOverText: {fileID: 0}
+  saucerSpawnPoint: {fileID: 0}
+  m_DelayedStartTime: 5
+  m_TickPeriodic:
+    m_InternalValue: 0.2
+  m_EnemyMovingDirection:
+    m_InternalValue: 0.3
+  m_RandomThresholdForSaucerCreation: 0.92

--- a/Basic/Invaders/Assets/Prefabs/enemy1.prefab
+++ b/Basic/Invaders/Assets/Prefabs/enemy1.prefab
@@ -10,11 +10,11 @@ GameObject:
   m_Component:
   - component: {fileID: 400000}
   - component: {fileID: 21200000}
+  - component: {fileID: 2037077820506562951}
   - component: {fileID: 11400000}
   - component: {fileID: 6100000}
   - component: {fileID: 5000000}
   - component: {fileID: 4223722966607089368}
-  - component: {fileID: 2037077820506562951}
   m_Layer: 0
   m_Name: enemy1
   m_TagString: Untagged
@@ -29,13 +29,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100000}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -2.521718, y: 0.97297525, z: 2.9156828}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &21200000
 SpriteRenderer:
@@ -89,6 +89,27 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &2037077820506562951
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 416377817
+  InScenePlacedSourceGlobalObjectIdHash: 0
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -102,7 +123,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   score: 10
-  bulletPrefab: {fileID: 100000, guid: ac6ffb0923d0f7448852a32312a0263c, type: 3}
+  bulletPrefab: {fileID: 2336033219118315817, guid: ac6ffb0923d0f7448852a32312a0263c,
+    type: 3}
   GraceShootingPeriod: 1
 --- !u!61 &6100000
 BoxCollider2D:
@@ -114,6 +136,25 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -147,6 +188,12 @@ Rigidbody2D:
   m_AngularDrag: 0.05
   m_GravityScale: 0
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
@@ -163,6 +210,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  UseUnreliableDeltas: 0
   SyncPositionX: 1
   SyncPositionY: 1
   SyncPositionZ: 1
@@ -175,22 +223,9 @@ MonoBehaviour:
   PositionThreshold: 0
   RotAngleThreshold: 0
   ScaleThreshold: 0
+  UseQuaternionSynchronization: 0
+  UseQuaternionCompression: 0
+  UseHalfFloatPrecision: 0
   InLocalSpace: 0
   Interpolate: 1
-  CanCommitToTransform: 0
---- !u!114 &2037077820506562951
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 100000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
-  AlwaysReplicateAsRoot: 0
-  DontDestroyWithOwner: 0
-  AutoObjectParentSync: 1
+  SlerpPosition: 0

--- a/Basic/Invaders/Assets/Prefabs/enemy2.prefab
+++ b/Basic/Invaders/Assets/Prefabs/enemy2.prefab
@@ -29,12 +29,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100000}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -3.3369913, y: 1.6158211, z: 5.338147}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &21200000
 SpriteRenderer:
@@ -47,6 +48,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -100,7 +102,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   score: 20
-  bulletPrefab: {fileID: 100000, guid: ac6ffb0923d0f7448852a32312a0263c, type: 3}
+  bulletPrefab: {fileID: 2336033219118315817, guid: ac6ffb0923d0f7448852a32312a0263c,
+    type: 3}
   GraceShootingPeriod: 1
 --- !u!61 &6100000
 BoxCollider2D:
@@ -112,6 +115,25 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -145,6 +167,12 @@ Rigidbody2D:
   m_AngularDrag: 0.05
   m_GravityScale: 0
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
@@ -161,6 +189,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  UseUnreliableDeltas: 0
   SyncPositionX: 1
   SyncPositionY: 1
   SyncPositionZ: 1
@@ -173,9 +202,12 @@ MonoBehaviour:
   PositionThreshold: 0
   RotAngleThreshold: 0
   ScaleThreshold: 0
+  UseQuaternionSynchronization: 0
+  UseQuaternionCompression: 0
+  UseHalfFloatPrecision: 0
   InLocalSpace: 0
   Interpolate: 1
-  CanCommitToTransform: 0
+  SlerpPosition: 0
 --- !u!114 &1361474663871475650
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,7 +220,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
+  GlobalObjectIdHash: 3854485402
+  InScenePlacedSourceGlobalObjectIdHash: 0
   AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1

--- a/Basic/Invaders/Assets/Prefabs/enemy3.prefab
+++ b/Basic/Invaders/Assets/Prefabs/enemy3.prefab
@@ -29,12 +29,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100000}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -2.877448, y: 1.0368326, z: 3.9234695}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &21200000
 SpriteRenderer:
@@ -47,6 +48,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -100,7 +102,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   score: 30
-  bulletPrefab: {fileID: 100000, guid: ac6ffb0923d0f7448852a32312a0263c, type: 3}
+  bulletPrefab: {fileID: 2336033219118315817, guid: ac6ffb0923d0f7448852a32312a0263c,
+    type: 3}
   GraceShootingPeriod: 1
 --- !u!61 &6100000
 BoxCollider2D:
@@ -112,6 +115,25 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -145,6 +167,12 @@ Rigidbody2D:
   m_AngularDrag: 0.05
   m_GravityScale: 0
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
@@ -161,6 +189,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  UseUnreliableDeltas: 0
   SyncPositionX: 1
   SyncPositionY: 1
   SyncPositionZ: 1
@@ -173,9 +202,12 @@ MonoBehaviour:
   PositionThreshold: 0.001
   RotAngleThreshold: 0.01
   ScaleThreshold: 0.01
+  UseQuaternionSynchronization: 0
+  UseQuaternionCompression: 0
+  UseHalfFloatPrecision: 0
   InLocalSpace: 0
   Interpolate: 1
-  CanCommitToTransform: 0
+  SlerpPosition: 0
 --- !u!114 &7651551376209856180
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,7 +220,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
+  GlobalObjectIdHash: 3432298371
+  InScenePlacedSourceGlobalObjectIdHash: 0
   AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1

--- a/Basic/Invaders/Assets/Prefabs/player.prefab
+++ b/Basic/Invaders/Assets/Prefabs/player.prefab
@@ -10,10 +10,10 @@ GameObject:
   m_Component:
   - component: {fileID: 400000}
   - component: {fileID: 21200000}
+  - component: {fileID: 5053919295125167455}
   - component: {fileID: 11400000}
   - component: {fileID: 6100000}
   - component: {fileID: 5000000}
-  - component: {fileID: 5053919295125167455}
   - component: {fileID: 2800302518702725854}
   m_Layer: 0
   m_Name: player
@@ -29,13 +29,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100000}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -3.2296677, y: 1.0967851, z: 6.24889}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &21200000
 SpriteRenderer:
@@ -89,6 +89,27 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &5053919295125167455
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 915374853
+  InScenePlacedSourceGlobalObjectIdHash: 0
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -101,7 +122,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 74fc8e136514c41458e083092b30afed, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 100000, guid: 6dfb311828493c3409e0f7973872052e, type: 3}
+  bulletPrefab: {fileID: 2859882261451710602, guid: 6dfb311828493c3409e0f7973872052e,
+    type: 3}
   m_MoveSpeed: 4.5
   m_Lives:
     m_InternalValue: 3
@@ -121,6 +143,25 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -154,26 +195,16 @@ Rigidbody2D:
   m_AngularDrag: 0.05
   m_GravityScale: 0
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!114 &5053919295125167455
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 100000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
-  AlwaysReplicateAsRoot: 0
-  DontDestroyWithOwner: 0
-  AutoObjectParentSync: 1
 --- !u!114 &2800302518702725854
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -186,6 +217,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: df2868252ab5c4d1da357e8f11f1b524, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  UseUnreliableDeltas: 0
   SyncPositionX: 1
   SyncPositionY: 0
   SyncPositionZ: 0
@@ -198,5 +230,9 @@ MonoBehaviour:
   PositionThreshold: 0.001
   RotAngleThreshold: 0.01
   ScaleThreshold: 0.01
+  UseQuaternionSynchronization: 0
+  UseQuaternionCompression: 0
+  UseHalfFloatPrecision: 0
   InLocalSpace: 0
   Interpolate: 1
+  SlerpPosition: 0

--- a/Basic/Invaders/Assets/Prefabs/superEnemy.prefab
+++ b/Basic/Invaders/Assets/Prefabs/superEnemy.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 400000}
   - component: {fileID: 21200000}
   - component: {fileID: 5000000}
+  - component: {fileID: 3955316467729786863}
   - component: {fileID: 11400006}
   - component: {fileID: 11400004}
   - component: {fileID: 6100000}
   - component: {fileID: 8984612552865464625}
-  - component: {fileID: 3955316467729786863}
   m_Layer: 0
   m_Name: superEnemy
   m_TagString: Untagged
@@ -30,12 +30,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100000}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1.2698746, y: 0.8354411, z: -1.6262951}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &21200000
 SpriteRenderer:
@@ -48,6 +49,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -105,10 +107,37 @@ Rigidbody2D:
   m_AngularDrag: 0.05
   m_GravityScale: 0
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!114 &3955316467729786863
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 1887726101
+  InScenePlacedSourceGlobalObjectIdHash: 0
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
 --- !u!114 &11400006
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -122,7 +151,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   score: 75
-  bulletPrefab: {fileID: 100000, guid: ac6ffb0923d0f7448852a32312a0263c, type: 3}
+  bulletPrefab: {fileID: 2336033219118315817, guid: ac6ffb0923d0f7448852a32312a0263c,
+    type: 3}
   GraceShootingPeriod: 1
 --- !u!114 &11400004
 MonoBehaviour:
@@ -147,6 +177,25 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -175,6 +224,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96cb6065543e43c4a752faaa1468eb1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  UseUnreliableDeltas: 0
   SyncPositionX: 1
   SyncPositionY: 1
   SyncPositionZ: 1
@@ -187,22 +237,9 @@ MonoBehaviour:
   PositionThreshold: 0.001
   RotAngleThreshold: 0.01
   ScaleThreshold: 0.01
+  UseQuaternionSynchronization: 0
+  UseQuaternionCompression: 0
+  UseHalfFloatPrecision: 0
   InLocalSpace: 0
   Interpolate: 1
-  CanCommitToTransform: 0
---- !u!114 &3955316467729786863
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 100000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
-  AlwaysReplicateAsRoot: 0
-  DontDestroyWithOwner: 0
-  AutoObjectParentSync: 1
+  SlerpPosition: 0

--- a/Basic/Invaders/Assets/Scripts/EnemyAgent.cs
+++ b/Basic/Invaders/Assets/Scripts/EnemyAgent.cs
@@ -1,4 +1,5 @@
 using System;
+using Unity.Mathematics;
 using Unity.Netcode;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -10,7 +11,7 @@ public class EnemyAgent : NetworkBehaviour
     private const float k_ShootTimer = 1.25f;
     [Header("Enemy Settings")]
     public int score = 50;
-    public GameObject bulletPrefab;
+    public NetworkObject bulletPrefab;
     public float GraceShootingPeriod = 1.0f; // A period of time in which the enemy will not shoot at the start
 
     public bool canShoot { get; set; }
@@ -80,8 +81,9 @@ public class EnemyAgent : NetworkBehaviour
 
     private void SpawnBullet()
     {
-        var myBullet = Instantiate(bulletPrefab, transform.position - Vector3.up, Quaternion.identity);
-        myBullet.GetComponent<NetworkObject>().Spawn();
+        bulletPrefab.InstantiateAndSpawn(NetworkManager.Singleton,
+            position: transform.position - Vector3.up,
+            rotation: quaternion.identity);
     }
 
     private void OnTriggerEnter2D(Collider2D collider)

--- a/Basic/Invaders/Assets/Scripts/EnemyBullet.cs
+++ b/Basic/Invaders/Assets/Scripts/EnemyBullet.cs
@@ -74,15 +74,15 @@ public class EnemyBullet : NetworkBehaviour
         var hitShield = collider.gameObject.GetComponent<Shield>();
         if (hitShield != null)
         {
-            SpawnExplosionVFXClientRpc(transform.position, Quaternion.identity);
+            ClientSpawnExplosionVFXRpc(transform.position, Quaternion.identity);
 
             Destroy(hitShield.gameObject);
             NetworkObject.Despawn();
         }
     }
 
-    [ClientRpc]
-    void SpawnExplosionVFXClientRpc(Vector3 spawnPosition, Quaternion spawnRotation)
+    [Rpc(SendTo.ClientsAndHost)]
+    void ClientSpawnExplosionVFXRpc(Vector3 spawnPosition, Quaternion spawnRotation)
     {
         Instantiate(m_ShieldExplosionParticle, spawnPosition, spawnRotation);
     }

--- a/Basic/Invaders/Assets/Scripts/InvadersGame.cs
+++ b/Basic/Invaders/Assets/Scripts/InvadersGame.cs
@@ -148,7 +148,7 @@ public class InvadersGame : NetworkBehaviour
             m_Shields.Clear();
         }
 
-        NetworkManager.Singleton.OnClientConnectedCallback -= OnClientConnected;
+        NetworkManager.Singleton.OnConnectionEvent -= OnClientConnected;
     }
 
     internal static event Action OnSingletonReady;
@@ -187,18 +187,21 @@ public class InvadersGame : NetworkBehaviour
 
         if (IsServer)
         {
-            NetworkManager.Singleton.OnClientConnectedCallback += OnClientConnected;
+            NetworkManager.Singleton.OnConnectionEvent += OnClientConnected;
         }
 
         base.OnNetworkSpawn();
     }
 
-    private void OnClientConnected(ulong clientId)
+    private void OnClientConnected(NetworkManager networkManager, ConnectionEventData connectionEventData)
     {
+        if (connectionEventData.EventType != ConnectionEvent.ClientConnected)
+            return;
+
         if (m_ReplicatedTimeSent)
         {
             // Send the RPC only to the newly connected client
-            ClientSetReplicatedTimeRemainingRPC(m_TimeRemaining, RpcTarget.Single(clientId, RpcTargetUse.Temp));
+            ClientSetReplicatedTimeRemainingRPC(m_TimeRemaining, RpcTarget.Single(connectionEventData.ClientId, RpcTargetUse.Temp));
         }
     }
 

--- a/Basic/Invaders/Assets/Scripts/LobbyControl.cs
+++ b/Basic/Invaders/Assets/Scripts/LobbyControl.cs
@@ -77,7 +77,7 @@ public class LobbyControl : NetworkBehaviour
 
         foreach (var clientLobbyStatus in m_ClientsInLobby)
         {
-            SendClientReadyStatusUpdatesClientRpc(clientLobbyStatus.Key, clientLobbyStatus.Value);
+            ClientSendReadyStatusUpdatesRpc(clientLobbyStatus.Key, clientLobbyStatus.Value);
             if (!NetworkManager.Singleton.ConnectedClients.ContainsKey(clientLobbyStatus.Key))
 
                 //If some clients are still loading into the lobby scene then this is false
@@ -124,14 +124,14 @@ public class LobbyControl : NetworkBehaviour
     }
 
     /// <summary>
-    ///     SendClientReadyStatusUpdatesClientRpc
+    ///     ClientSendReadyStatusUpdatesRpc
     ///     Sent from the server to the client when a player's status is updated.
     ///     This also populates the connected clients' (excluding host) player state in the lobby
     /// </summary>
     /// <param name="clientId"></param>
     /// <param name="isReady"></param>
-    [ClientRpc]
-    private void SendClientReadyStatusUpdatesClientRpc(ulong clientId, bool isReady)
+    [Rpc(SendTo.ClientsAndHost)]
+    private void ClientSendReadyStatusUpdatesRpc(ulong clientId, bool isReady)
     {
         if (!IsServer)
         {
@@ -186,7 +186,7 @@ public class LobbyControl : NetworkBehaviour
         }
         else
         {
-            OnClientIsReadyServerRpc(NetworkManager.Singleton.LocalClientId);
+            ServerOnClientIsReadyRpc(NetworkManager.Singleton.LocalClientId);
         }
 
         GenerateUserStatsForLobby();
@@ -197,8 +197,8 @@ public class LobbyControl : NetworkBehaviour
     ///     Sent to the server when the player clicks the ready button
     /// </summary>
     /// <param name="clientid">clientId that is ready</param>
-    [ServerRpc(RequireOwnership = false)]
-    private void OnClientIsReadyServerRpc(ulong clientid)
+    [Rpc(SendTo.Server)]
+    private void ServerOnClientIsReadyRpc(ulong clientid)
     {
         if (m_ClientsInLobby.ContainsKey(clientid))
         {

--- a/Basic/Invaders/Assets/Scripts/PlayerBullet.cs
+++ b/Basic/Invaders/Assets/Scripts/PlayerBullet.cs
@@ -50,7 +50,7 @@ public class PlayerBullet : NetworkBehaviour
             // Only the server can despawn a NetworkObject
             hitEnemy.NetworkObject.Despawn();
 
-            SpawnExplosionVFXClientRPC(transform.position, Quaternion.identity);
+            ClientSpawnExplosionVFXRPC(transform.position, Quaternion.identity);
 
             NetworkObject.Despawn();
 
@@ -65,10 +65,10 @@ public class PlayerBullet : NetworkBehaviour
         }
     }
 
-    [ClientRpc]
-    void SpawnExplosionVFXClientRPC(Vector3 spawnPosition, Quaternion spawnRotation)
+    [Rpc(SendTo.ClientsAndHost)]
+    void ClientSpawnExplosionVFXRPC(Vector3 spawnPosition, Quaternion spawnRotation)
     {
-        // this instantiates at the position of the bullet, there is an offset in the Y axis on the 
+        // this instantiates at the position of the bullet, there is an offset in the Y axis on the
         // particle systems in the prefab so it looks like it spawns in the middle of the enemy
         Instantiate(m_EnemyExplosionParticle, spawnPosition, spawnRotation);
     }

--- a/Basic/Invaders/Assets/Scripts/PlayerControl.cs
+++ b/Basic/Invaders/Assets/Scripts/PlayerControl.cs
@@ -3,12 +3,11 @@ using Unity.Mathematics;
 using Unity.Netcode;
 using UnityEngine;
 using UnityEngine.Assertions;
-using UnityEngine.Rendering.VirtualTexturing;
 
 public class PlayerControl : NetworkBehaviour
 {
     [Header("Weapon Settings")]
-    public GameObject bulletPrefab;
+    public NetworkObject bulletPrefab;
 
     [Header("Movement Settings")]
     [SerializeField]
@@ -32,7 +31,7 @@ public class PlayerControl : NetworkBehaviour
 
     private NetworkVariable<int> m_MoveX = new NetworkVariable<int>(0);
 
-    private GameObject m_MyBullet;
+    private NetworkObject m_MyBullet;
 
     [SerializeField]
     private SpriteRenderer m_PlayerVisual;
@@ -198,9 +197,10 @@ public class PlayerControl : NetworkBehaviour
 
         if (m_MyBullet == null)
         {
-            m_MyBullet = Instantiate(bulletPrefab, transform.position + Vector3.up, Quaternion.identity);
+            m_MyBullet = bulletPrefab.InstantiateAndSpawn(NetworkManager.Singleton,
+                position: transform.position + Vector3.up,
+                rotation: Quaternion.identity);
             m_MyBullet.GetComponent<PlayerBullet>().owner = this;
-            m_MyBullet.GetComponent<NetworkObject>().Spawn();
         }
     }
 

--- a/Basic/Invaders/Packages/manifest.json
+++ b/Basic/Invaders/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop#v2.4.0",
     "com.unity.multiplayer.tools": "1.1.1",
-    "com.unity.netcode.gameobjects": "1.7.1",
+    "com.unity.netcode.gameobjects": "1.8.1",
     "com.unity.render-pipelines.universal": "14.0.11",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.6",

--- a/Basic/Invaders/Packages/packages-lock.json
+++ b/Basic/Invaders/Packages/packages-lock.json
@@ -117,7 +117,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.netcode.gameobjects": {
-      "version": "1.7.1",
+      "version": "1.8.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Basic/Invaders/README.md
+++ b/Basic/Invaders/README.md
@@ -4,7 +4,7 @@
 # Invaders
 
 [![UnityVersion](https://img.shields.io/badge/Unity%20Version:-2022.3%20LTS-57b9d3.svg?logo=unity&color=2196F3)](https://unity.com/releases/editor/whats-new/2022.3.0)
-[![NetcodeVersion](https://img.shields.io/badge/Netcode%20Version:-1.7.1-57b9d3.svg?logo=unity&color=2196F3)](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/releases/tag/ngo%2F1.7.1)
+[![NetcodeVersion](https://img.shields.io/badge/Netcode%20Version:-1.8.1-57b9d3.svg?logo=unity&color=2196F3)](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/releases/tag/ngo%2F1.8.1)
 [![LatestRelease](https://img.shields.io/badge/Latest%20%20Github%20Release:-v1.5.0-57b9d3.svg?logo=github&color=brightgreen)](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.bitesize/releases/tag/v1.5.0)
 <br><br>
 


### PR DESCRIPTION
### Description
- Upgraded NGO to 1.8.1
- Changed usage of ClientRPC and ServerRPC to the unified RPCAttribute.
- Changed OnClientConnectedCallback registration to use the new OnConnectionEvent.
- Changing spawn methods to use InstantiateAndSpawn.

### Issue Number(s)
[MTT-8503](https://jira.unity3d.com/browse/MTT-8503) Upgrade Invaders to use Netcode For Gameobject 1.8.1 and changed code to new recommended API.

### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
