### PR TITLE
feat: DynamicAddressablesNetworkPrefabs upgraded to 2022.3.27f1 [MTT-8513]

### DIFF
--- a/Basic/DynamicAddressablesNetworkPrefabs/Packages/packages-lock.json
+++ b/Basic/DynamicAddressablesNetworkPrefabs/Packages/packages-lock.json
@@ -24,11 +24,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.burst": {
-      "version": "1.8.10",
+      "version": "1.8.13",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.unity.mathematics": "1.2.1"
+        "com.unity.mathematics": "1.2.1",
+        "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -153,7 +154,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/Basic/DynamicAddressablesNetworkPrefabs/ProjectSettings/ProjectVersion.txt
+++ b/Basic/DynamicAddressablesNetworkPrefabs/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.14f1
-m_EditorVersionWithRevision: 2022.3.14f1 (eff2de9070d8)
+m_EditorVersion: 2022.3.27f1
+m_EditorVersionWithRevision: 2022.3.27f1 (73effa14754f)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 #### Changed
 - Upgraded to IDE Rider v3.0.28 (#166)
+- Upgraded to Unity 2022.3.27f1 (#176)
+  - com.unity.transport upgraded to v1.4.1
 
 ### Invaders
 


### PR DESCRIPTION
### Description
PR to upgrade DynamicAddressablesNetworkPrefabs to Unity 2022.3.27f1 LTS.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTT-8513](https://jira.unity3d.com/browse/MTT-8513)
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for the project and/or any internal package
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
