### PR TITLE
fix: releasing Addressables handle on OnDestroy in DynamicAddressablesNetworkPrefabs Preloading scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@
 - Upgraded to Unity 2022.3.27f1 (#176)
   - com.unity.transport upgraded to v1.4.1
 
+#### Fixed
+- Releasing an Addressables handle on OnDestroy inside Preloading scene to prevent releasing loaded dynamic prefab from memory (#179)
+
 ### Invaders
 
 #### Changed


### PR DESCRIPTION
### Description
A bug was discovered when testing Preloading scene where the Dynamic Prefab loading in Preloading scene was null, due to the Addressables handle being released as soon as the prefab was loaded.

The Release call was moved to this MonoBehaviour's OnDestroy method.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
N/A
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

To Test:
Load 00_Preloading Dynamic Prefabs scene.
Host on one instance.
See that the warnings shared below don't appear on console.
Verify that the same is for a joining client.

<img width="756" alt="Screenshot 2024-05-21 at 14 28 33" src="https://github.com/Unity-Technologies/com.unity.multiplayer.samples.bitesize/assets/75813458/89d4ad09-e041-4b1c-b525-3e4b0ccd8a3d">

### Contribution checklist
 - [ N/A ] Tests have been added for the project and/or any internal package
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ N/A ] JIRA ticket ID is in the PR title or at least one commit message
 - [ N/A ] Include the ticket ID number within the body message of the PR to create a hyperlink
