### PR TITLE
mtt-8638-Separate-PR-Triggers-per-project

### DIFF
--- a/.yamato/2DSpaceShooter_triggers.yml
+++ b/.yamato/2DSpaceShooter_triggers.yml
@@ -1,0 +1,46 @@
+{% metadata_file .yamato/project.metafile %}
+---
+
+# Run all relevant tasks when a pull request targets the develop / main or a sample branch
+pull_request_trigger:
+  name: 2DSpaceShooter Pull Request Trigger (main, develop, & sample branches)
+  dependencies:
+{% for project in projects -%}
+{% if project.name =="2dspaceshooter" -%}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% if project.run_editor_tests or project.run_playmode_tests -%} # Only run tests for projects where relevant
+    - .yamato/tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
+  triggers:
+    cancel_old_ci: true
+    expression: |-
+     (pull_request.target eq "main" OR
+      pull_request.target eq "develop" OR
+      pull_request.target match "/^sample\//") AND
+      NOT pull_request.draft AND
+      pull_request.changes.any match "Basic/2DSpaceShooter/**/*"
+      
+
+# Run all tasks on the bitesize sample develop branch (head) when there is a push to the Netcode for GameObjects develop branch
+external_ngo_develop_pull_request_trigger:
+  name: Netcode for GameObjects (External) Develop Branch Triggers
+  dependencies:
+{% for project in projects -%}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+  triggers:
+    external:
+      source: git@github.com/Unity-Technologies/com.unity.netcode.gameobjects.git
+      expression: push.branch eq "develop"
+      refs_on_this_repository:
+        - develop

--- a/.yamato/ClientDriven_triggers.yml
+++ b/.yamato/ClientDriven_triggers.yml
@@ -3,9 +3,10 @@
 
 # Run all relevant tasks when a pull request targets the develop / main or a sample branch
 pull_request_trigger:
-  name: Pull Request Trigger (main, develop, & sample branches)
+  name: ClientDriven Pull Request Trigger (main, develop, & sample branches)
   dependencies:
 {% for project in projects -%}
+{% if project.name =="clientdriven" -%}
 {% for editor in project.test_editors -%}
 {% for platform in test_platforms -%}
     - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
@@ -14,15 +15,16 @@ pull_request_trigger:
 {% endif -%}
 {% endfor -%}
 {% endfor -%}
+{% endif -%}
 {% endfor -%}
   triggers:
     cancel_old_ci: true
-    pull_requests:
-    - targets:
-        only:
-          - "main"
-          - "develop"
-          - "/^sample\//"
+    expression: |-
+     (pull_request.target eq "main" OR
+      pull_request.target eq "develop" OR
+      pull_request.target match "/^sample\//") AND
+      NOT pull_request.draft AND
+      pull_request.changes.any match "Basic/ClientDriven/**/*"
 
 # Run all tasks on the bitesize sample develop branch (head) when there is a push to the Netcode for GameObjects develop branch
 external_ngo_develop_pull_request_trigger:

--- a/.yamato/DedicatedGameServer_triggers.yml
+++ b/.yamato/DedicatedGameServer_triggers.yml
@@ -1,0 +1,45 @@
+{% metadata_file .yamato/project.metafile %}
+---
+
+# Run all relevant tasks when a pull request targets the develop / main or a sample branch
+pull_request_trigger:
+  name: DedicatedGameServer Pull Request Trigger (main, develop, & sample branches)
+  dependencies:
+{% for project in projects -%}
+{% if project.name =="dedicatedgameserver" -%}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% if project.run_editor_tests or project.run_playmode_tests -%} # Only run tests for projects where relevant
+    - .yamato/tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
+  triggers:
+    cancel_old_ci: true
+    expression: |-
+     (pull_request.target eq "main" OR
+      pull_request.target eq "develop" OR
+      pull_request.target match "/^sample\//") AND
+      NOT pull_request.draft AND
+      pull_request.changes.any match "Experimental/DedicatedGameServer/**/*"
+
+# Run all tasks on the bitesize sample develop branch (head) when there is a push to the Netcode for GameObjects develop branch
+external_ngo_develop_pull_request_trigger:
+  name: Netcode for GameObjects (External) Develop Branch Triggers
+  dependencies:
+{% for project in projects -%}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+  triggers:
+    external:
+      source: git@github.com/Unity-Technologies/com.unity.netcode.gameobjects.git
+      expression: push.branch eq "develop"
+      refs_on_this_repository:
+        - develop

--- a/.yamato/MultiplayerUseCases_triggers.yml
+++ b/.yamato/MultiplayerUseCases_triggers.yml
@@ -1,0 +1,45 @@
+{% metadata_file .yamato/project.metafile %}
+---
+
+# Run all relevant tasks when a pull request targets the develop / main or a sample branch
+pull_request_trigger:
+  name: MultiplayerUseCases Pull Request Trigger (main, develop, & sample branches)
+  dependencies:
+{% for project in projects -%}
+{% if project.name =="multiplayerusecases" -%}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% if project.run_editor_tests or project.run_playmode_tests -%} # Only run tests for projects where relevant
+    - .yamato/tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
+  triggers:
+    cancel_old_ci: true
+    expression: |-
+     (pull_request.target eq "main" OR
+      pull_request.target eq "develop"  OR
+      pull_request.target match "/^sample\//") AND
+      NOT pull_request.draft AND
+      pull_request.changes.any match "Experimental/MultiplayerUseCases/**/*"
+
+# Run all tasks on the bitesize sample develop branch (head) when there is a push to the Netcode for GameObjects develop branch
+external_ngo_develop_pull_request_trigger:
+  name: Netcode for GameObjects (External) Develop Branch Triggers
+  dependencies:
+{% for project in projects -%}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+  triggers:
+    external:
+      source: git@github.com/Unity-Technologies/com.unity.netcode.gameobjects.git
+      expression: push.branch eq "develop"
+      refs_on_this_repository:
+        - develop

--- a/.yamato/dynamicaddressablesnetworkprefabs_triggers.yml
+++ b/.yamato/dynamicaddressablesnetworkprefabs_triggers.yml
@@ -1,0 +1,45 @@
+{% metadata_file .yamato/project.metafile %}
+---
+
+# Run all relevant tasks when a pull request targets the develop / main or a sample branch
+pull_request_trigger:
+  name: DynamicAddressablesNetworkPrefabs Pull Request Trigger (main, develop, & sample branches)
+  dependencies:
+{% for project in projects -%}
+{% if project.name =="dynamicaddressablesnetworkprefabs" -%}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% if project.run_editor_tests or project.run_playmode_tests -%} # Only run tests for projects where relevant
+    - .yamato/tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
+  triggers:
+    cancel_old_ci: true
+    expression: |-
+     (pull_request.target eq "main" OR
+      pull_request.target eq "develop" OR
+      pull_request.target match "/^sample\//") AND
+      NOT pull_request.draft AND
+      pull_request.changes.any match "Basic/DynamicAddressablesNetworkPrefabs/**/*"
+
+# Run all tasks on the bitesize sample develop branch (head) when there is a push to the Netcode for GameObjects develop branch
+external_ngo_develop_pull_request_trigger:
+  name: Netcode for GameObjects (External) Develop Branch Triggers
+  dependencies:
+{% for project in projects -%}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+  triggers:
+    external:
+      source: git@github.com/Unity-Technologies/com.unity.netcode.gameobjects.git
+      expression: push.branch eq "develop"
+      refs_on_this_repository:
+        - develop

--- a/.yamato/shared_triggers.yml
+++ b/.yamato/shared_triggers.yml
@@ -1,0 +1,45 @@
+{% metadata_file .yamato/project.metafile %}
+---
+
+# Run all relevant tasks when a pull request targets the develop / main or a sample branch
+pull_request_trigger:
+  name: Shared Pull Request Trigger (main, develop, & sample branches)
+  dependencies:
+{% for project in projects -%}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% if project.run_editor_tests or project.run_playmode_tests -%} # Only run tests for projects where relevant
+    - .yamato/tests.yml#test_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+  triggers:
+    cancel_old_ci: true
+    expression: |-
+     (pull_request.target eq "main" OR
+      pull_request.target eq "develop" OR
+      pull_request.target match "/^sample\//") AND
+      NOT pull_request.draft AND
+      (NOT pull_request.changes.any match "Basic/**/*" AND 
+       NOT pull_request.changes.any match "Experimental/**/*")
+      
+
+# Run all tasks on the bitesize sample develop branch (head) when there is a push to the Netcode for GameObjects develop branch
+external_ngo_develop_pull_request_trigger:
+  name: Netcode for GameObjects (External) Develop Branch Triggers
+  dependencies:
+{% for project in projects -%}
+{% for editor in project.test_editors -%}
+{% for platform in test_platforms -%}
+    - .yamato/build.yml#build_{{ project.name }}_{{ editor }}_{{ platform.name }}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+  triggers:
+    external:
+      source: git@github.com/Unity-Technologies/com.unity.netcode.gameobjects.git
+      expression: push.branch eq "develop"
+      refs_on_this_repository:
+        - develop

--- a/.yamato/shared_triggers.yml
+++ b/.yamato/shared_triggers.yml
@@ -3,7 +3,7 @@
 
 # Run all relevant tasks when a pull request targets the develop / main or a sample branch
 pull_request_trigger:
-  name: Shared Pull Request Trigger (main, develop, & sample branches)
+  name: Pull Request Trigger (main, develop, & sample branches)
   dependencies:
 {% for project in projects -%}
 {% for editor in project.test_editors -%}


### PR DESCRIPTION
### Description
<!---
Adjust Samples tests to be more efficient
Creating separate PR Triggers for each project in multiplayer.samples.bitesize , so only relevant test to the project is run when a change is made instead of running tests for all the projects. Details in the ticket

There was an earlier PR for this job but it was getting stuck as Yamato continued to execute job based on old trigger since the old trigger was not removed at initial commit. This is an attempt to stop Yamato from trying to run old job from the first commit. 
-->

### Issue Number(s)
<!---
(https://jira.unity3d.com/browse/MTT-8638)
-->

### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
