### PR TITLE
fix: scene loading small demo event notification registration and order of operations

### DIFF
--- a/Experimental/Asteroids-CMB-NGO-Sample/Assets/Scenes/SmallDemos/SceneLoading/FirstScene.unity
+++ b/Experimental/Asteroids-CMB-NGO-Sample/Assets/Scenes/SmallDemos/SceneLoading/FirstScene.unity
@@ -38,7 +38,6 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -421,7 +420,7 @@ GameObject:
   - component: {fileID: 1002758052}
   - component: {fileID: 1002758051}
   m_Layer: 0
-  m_Name: SessionOwnerGUI
+  m_Name: SessionOwnerGUI-1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -443,6 +442,8 @@ MonoBehaviour:
   - TestScene1
   - TestScene2
   m_TransitionToScene: SecondScene
+  m_EndSessionScene: 
+  EndSessionScene: {fileID: 0}
   TransistionToScene: {fileID: 102900000, guid: 44c38a04bf0dfd547aafac271c9ec08c, type: 3}
   ScenesToLoad:
   - {fileID: 102900000, guid: e038f8eba64670b4d87ec415baf622d6, type: 3}

--- a/Experimental/Asteroids-CMB-NGO-Sample/Assets/Scenes/SmallDemos/SceneLoading/SecondScene.unity
+++ b/Experimental/Asteroids-CMB-NGO-Sample/Assets/Scenes/SmallDemos/SceneLoading/SecondScene.unity
@@ -38,7 +38,6 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -421,7 +420,7 @@ GameObject:
   - component: {fileID: 1002758052}
   - component: {fileID: 1002758051}
   m_Layer: 0
-  m_Name: SessionOwnerGUI
+  m_Name: SessionOwnerGUI-2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -445,6 +444,8 @@ MonoBehaviour:
   - TestScene3
   - TestScene4
   m_TransitionToScene: FirstScene
+  m_EndSessionScene: 
+  EndSessionScene: {fileID: 0}
   TransistionToScene: {fileID: 102900000, guid: 8d79a902790e034499ee3f928658c1e6, type: 3}
   ScenesToLoad:
   - {fileID: 102900000, guid: e038f8eba64670b4d87ec415baf622d6, type: 3}

--- a/Experimental/Asteroids-CMB-NGO-Sample/Assets/Scripts/NetworkManagerHelper.cs
+++ b/Experimental/Asteroids-CMB-NGO-Sample/Assets/Scripts/NetworkManagerHelper.cs
@@ -283,6 +283,7 @@ public class NetworkManagerHelper : MonoBehaviour, IPoolSystemTracker
     public Action<StartModes> OnStarted;
 
     public Action OnExiting;
+    public Action OnShuttingDown;
 
     private float[] m_DeltaTimes = new float[60];
     private int[] m_DeltaTicks = new int[60];
@@ -624,6 +625,7 @@ public class NetworkManagerHelper : MonoBehaviour, IPoolSystemTracker
             GUILayout.BeginArea(new Rect(Display.main.renderingWidth - 40, 10, 30, 30));
             if (GUILayout.Button("X"))
             {
+                OnShuttingDown?.Invoke();
                 m_NetworkManager.Shutdown();
                 m_SelectedSessionType = false;
                 m_SessionType = SessionTypes.None;


### PR DESCRIPTION
### Description
This resolves some issues with the scene loading small demo where the `SceneLoadingUI` was not registering and deregistering all required notifications properly. It also includes and added event notification `NetworkManagerHelper.OnShuttingDown` that is invoked just prior to exiting a session and shutting down the `NetworkManager`. It also cleans up the `SceneLoadingUI`  bit more and consolidates the problematic event notification registration and deregistration into `SceneLoadingUI.AddSceneManagerCallbacks` and `SceneLoading.RemoveAllCallbacks`.

### Issue Number(s)
NA

### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
