### PR TITLE
fix: Distributed Authority Sample - Jitter on FixedJoint connected body

### DIFF
--- a/Experimental/DistributedAuthoritySample/Assets/ScriptableObjects/AvatarPhysicsPlayerControllerSettings.asset
+++ b/Experimental/DistributedAuthoritySample/Assets/ScriptableObjects/AvatarPhysicsPlayerControllerSettings.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 48976c2ba473849eab61b8e1398b8644, type: 3}
   m_Name: AvatarPhysicsPlayerControllerSettings
   m_EditorClassIdentifier: 
-  WalkSpeed: 6
-  SprintSpeed: 10
+  WalkSpeed: 18
+  SprintSpeed: 30
   Acceleration: 50
   DragCoefficient: 4
   AirControlFactor: 0.5

--- a/Experimental/DistributedAuthoritySample/Assets/Scripts/Physics/PhysicsPlayerController.cs
+++ b/Experimental/DistributedAuthoritySample/Assets/Scripts/Physics/PhysicsPlayerController.cs
@@ -71,13 +71,13 @@ namespace Unity.Multiplayer.Samples.SocialHub.Physics
             {
                 // Apply force proportional to acceleration while grounded
                 var force = velocityChange * m_PhysicsPlayerControllerSettings.Acceleration;
-                m_Rigidbody.AddForce(force, ForceMode.Acceleration);
+                m_Rigidbody.AddForce(force, ForceMode.Force);
             }
             else
             {
                 // Apply reduced force in the air for air control
                 var force = velocityChange * (m_PhysicsPlayerControllerSettings.Acceleration * m_PhysicsPlayerControllerSettings.AirControlFactor);
-                m_Rigidbody.AddForce(force, ForceMode.Acceleration);
+                m_Rigidbody.AddForce(force, ForceMode.Force);
             }
 
             // maybe add magnitude check?


### PR DESCRIPTION
### Description
Fix to the jitter issue on connected bodies on a FixedJoint. Changing to ForceMode.Force properly propagates movement to the child Rigidbody & FixedJoint.
Forces have been modified on the player's locomotion ScriptableObject to accommodate the introduction of mass to the force equation.

To test: pick up crate object and sprint with character -> notice no jitter.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
N/A
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] JIRA ticket ID is in the PR title or at least one commit message
 - [ ] Include the ticket ID number within the body message of the PR to create a hyperlink
