### PR TITLE
fix: Remove shader define FORWARD_PLUS

### DIFF
--- a/Experimental/DistributedAuthoritySample/Assets/Shaders/Toon.shadergraph
+++ b/Experimental/DistributedAuthoritySample/Assets/Shaders/Toon.shadergraph
@@ -33,9 +33,6 @@
     ],
     "m_Keywords": [
         {
-            "m_Id": "a86251b616334e3c8266155df1fcb321"
-        },
-        {
             "m_Id": "e6fcd2c583ac4014ae9bf2e1df511bba"
         }
     ],
@@ -694,7 +691,7 @@
     "m_StageCapability": 2,
     "m_BareResource": false,
     "m_Texture": {
-        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_SerializedTexture": "",
         "m_Guid": ""
     },
     "m_DefaultType": 0
@@ -1228,7 +1225,7 @@
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
     "m_Value": {
-        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_SerializedTexture": "",
         "m_Guid": ""
     },
     "isMainTexture": false,
@@ -1258,7 +1255,7 @@
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
     "m_Value": {
-        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_SerializedTexture": "",
         "m_Guid": ""
     },
     "isMainTexture": false,
@@ -1409,8 +1406,8 @@
     "m_ObjectId": "91fdea723e8a435e98d71d8800f8b735",
     "m_Title": "Emission",
     "m_Position": {
-        "x": 1275.4283447265625,
-        "y": -682.8570556640625
+        "x": 1275.5,
+        "y": -682.4999389648438
     }
 }
 
@@ -1421,7 +1418,7 @@
     "m_Title": "Alpha clipping support",
     "m_Position": {
         "x": 1030.0001220703125,
-        "y": 23.999961853027345
+        "y": 22.499996185302736
     }
 }
 
@@ -1588,8 +1585,8 @@
     "m_ObjectId": "9e4023633c0143749ce2c4808a8bc229",
     "m_Title": "Main Colour",
     "m_Position": {
-        "x": -119.0,
-        "y": -219.0000457763672
+        "x": -119.00001525878906,
+        "y": -218.50001525878907
     }
 }
 
@@ -1654,31 +1651,6 @@
         "Y",
         "Z"
     ]
-}
-
-{
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
-    "m_ObjectId": "a86251b616334e3c8266155df1fcb321",
-    "m_Guid": {
-        "m_GuidSerialized": "71ca0158-36ac-4638-963d-3f71541791c4"
-    },
-    "m_Name": "FORWARD_PLUS",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "FORWARD_PLUS",
-    "m_DefaultReferenceName": "_FORWARD_PLUS",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": false,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
-    "m_KeywordType": 0,
-    "m_KeywordDefinition": 1,
-    "m_KeywordScope": 1,
-    "m_KeywordStages": 2,
-    "m_Entries": [],
-    "m_Value": 0,
-    "m_IsEditable": true
 }
 
 {
@@ -2000,7 +1972,7 @@
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
     "m_Value": {
-        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_SerializedTexture": "",
         "m_Guid": ""
     },
     "isMainTexture": false,
@@ -2149,7 +2121,7 @@
     "m_StageCapability": 2,
     "m_BareResource": false,
     "m_Texture": {
-        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_SerializedTexture": "",
         "m_Guid": ""
     },
     "m_DefaultType": 0
@@ -2334,8 +2306,8 @@
     "m_ObjectId": "e4cc3f09ed254e1eabbffbf44401f100",
     "m_Title": "Specular",
     "m_Position": {
-        "x": 198.99996948242188,
-        "y": -453.0
+        "x": 199.0,
+        "y": -454.5
     }
 }
 
@@ -2351,7 +2323,7 @@
     "m_StageCapability": 2,
     "m_BareResource": false,
     "m_Texture": {
-        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_SerializedTexture": "",
         "m_Guid": ""
     },
     "m_DefaultType": 0
@@ -2438,9 +2410,6 @@
         },
         {
             "m_Id": "c7ddee4b9eaed98cb315fda2eafd5e7a"
-        },
-        {
-            "m_Id": "a86251b616334e3c8266155df1fcb321"
         },
         {
             "m_Id": "e6fcd2c583ac4014ae9bf2e1df511bba"


### PR DESCRIPTION
### Remove FORWARD_PLUS shader define, to fix MacOS Arm Build.

FORWARD_PLUS define enables some feature in MacOS Arm that breaks the build. This will be fixed within upcoming Unity Versions, in the meantime we remove the Define.


### Issue Number(s)
[MTT-9228](https://jira.unity3d.com/browse/MTT-9228)