### PR TITLE
fix: Distributed Authority Sample - listening to session exited callback to return to main menu [MTTB-551]

### DIFF
--- a/Experimental/DistributedAuthoritySample/Assets/Prefabs/Gameplay/InGameHandler.prefab
+++ b/Experimental/DistributedAuthoritySample/Assets/Prefabs/Gameplay/InGameHandler.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3324184757222927008
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 28543265347420830}
+  - component: {fileID: 9060878956782360255}
+  m_Layer: 0
+  m_Name: InGameHandler
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &28543265347420830
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3324184757222927008}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &9060878956782360255
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3324184757222927008}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 722e204d144204ae2b96cc9403e0d30a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Experimental/DistributedAuthoritySample/Assets/Prefabs/Gameplay/InGameHandler.prefab.meta
+++ b/Experimental/DistributedAuthoritySample/Assets/Prefabs/Gameplay/InGameHandler.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 077aed1e632ed45a19dac81f77467886
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Experimental/DistributedAuthoritySample/Assets/Prefabs/Gameplay/MainMenuHandler.prefab
+++ b/Experimental/DistributedAuthoritySample/Assets/Prefabs/Gameplay/MainMenuHandler.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6620477695853993140
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6633600782536336548}
+  - component: {fileID: -691112424570703035}
+  m_Layer: 0
+  m_Name: MainMenuHandler
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6633600782536336548
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6620477695853993140}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-691112424570703035
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6620477695853993140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64299a9624b2b4428a98998e7e365369, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Experimental/DistributedAuthoritySample/Assets/Prefabs/Gameplay/MainMenuHandler.prefab.meta
+++ b/Experimental/DistributedAuthoritySample/Assets/Prefabs/Gameplay/MainMenuHandler.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 19aae1db2fb8c4113ad2d5d31fcdddb3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Experimental/DistributedAuthoritySample/Assets/Scenes/MainMenu.unity
+++ b/Experimental/DistributedAuthoritySample/Assets/Scenes/MainMenu.unity
@@ -610,6 +610,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 062b3805bf6784e4d9c599ee60eaa002, type: 3}
+--- !u!1001 &1509432659
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6620477695853993140, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
+      propertyPath: m_Name
+      value: MainMenuHandler
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633600782536336548, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633600782536336548, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633600782536336548, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633600782536336548, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633600782536336548, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633600782536336548, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633600782536336548, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633600782536336548, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633600782536336548, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6633600782536336548, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19aae1db2fb8c4113ad2d5d31fcdddb3, type: 3}
 --- !u!1 &1774153429
 GameObject:
   m_ObjectHideFlags: 0
@@ -787,3 +844,4 @@ SceneRoots:
   - {fileID: 1479164695}
   - {fileID: 331074469}
   - {fileID: 241002143}
+  - {fileID: 1509432659}

--- a/Experimental/DistributedAuthoritySample/Assets/Scripts/GameManagement/GameplayEventHandler.cs
+++ b/Experimental/DistributedAuthoritySample/Assets/Scripts/GameManagement/GameplayEventHandler.cs
@@ -2,6 +2,7 @@ using Unity.Netcode;
 using UnityEngine;
 using System;
 using System.Threading.Tasks;
+using UnityEngine.SceneManagement;
 
 namespace Unity.Multiplayer.Samples.SocialHub.GameManagement
 {
@@ -13,6 +14,7 @@ namespace Unity.Multiplayer.Samples.SocialHub.GameManagement
         internal static event Action OnReturnToMainMenuButtonPressed;
         internal static event Action OnQuitGameButtonPressed;
         internal static event Action<Task> OnConnectToSessionCompleted;
+        internal static event Action OnExitedSession;
 
         internal static void NetworkObjectDespawned(NetworkObject networkObject)
         {
@@ -42,6 +44,21 @@ namespace Unity.Multiplayer.Samples.SocialHub.GameManagement
         internal static void ConnectToSessionComplete(Task task)
         {
             OnConnectToSessionCompleted?.Invoke(task);
+        }
+
+        internal static void ExitedSession()
+        {
+            OnExitedSession?.Invoke();
+        }
+
+        internal static void LoadMainMenuScene()
+        {
+            SceneManager.LoadScene("MainMenu");
+        }
+
+        internal static void LoadInGameScene()
+        {
+            SceneManager.LoadScene("HubScene_TownMarket");
         }
     }
 }

--- a/Experimental/DistributedAuthoritySample/Assets/Scripts/GameManagement/InGameHandler.cs
+++ b/Experimental/DistributedAuthoritySample/Assets/Scripts/GameManagement/InGameHandler.cs
@@ -1,0 +1,20 @@
+using System;
+using UnityEngine;
+
+namespace Unity.Multiplayer.Samples.SocialHub.GameManagement
+{
+    class InGameHandler : MonoBehaviour
+    {
+        void Start()
+        {
+            GameplayEventHandler.OnReturnToMainMenuButtonPressed += GameplayEventHandler.LoadMainMenuScene;
+            GameplayEventHandler.OnExitedSession += GameplayEventHandler.LoadMainMenuScene;
+        }
+
+        void OnDestroy()
+        {
+            GameplayEventHandler.OnReturnToMainMenuButtonPressed -= GameplayEventHandler.LoadMainMenuScene;
+            GameplayEventHandler.OnExitedSession -= GameplayEventHandler.LoadMainMenuScene;
+        }
+    }
+}

--- a/Experimental/DistributedAuthoritySample/Assets/Scripts/GameManagement/InGameHandler.cs.meta
+++ b/Experimental/DistributedAuthoritySample/Assets/Scripts/GameManagement/InGameHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 722e204d144204ae2b96cc9403e0d30a

--- a/Experimental/DistributedAuthoritySample/Assets/Scripts/GameManagement/MainMenuHandler.cs
+++ b/Experimental/DistributedAuthoritySample/Assets/Scripts/GameManagement/MainMenuHandler.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Unity.Multiplayer.Samples.SocialHub.GameManagement
+{
+    class MainMenuHandler : MonoBehaviour
+    {
+        void Start()
+        {
+            GameplayEventHandler.OnConnectToSessionCompleted += OnConnectToSessionCompleted;
+        }
+
+        void OnDestroy()
+        {
+            GameplayEventHandler.OnConnectToSessionCompleted -= OnConnectToSessionCompleted;
+        }
+
+        void OnConnectToSessionCompleted(Task task)
+        {
+            if (task.IsCompletedSuccessfully)
+            {
+                GameplayEventHandler.LoadInGameScene();
+            }
+        }
+    }
+}

--- a/Experimental/DistributedAuthoritySample/Assets/Scripts/GameManagement/MainMenuHandler.cs.meta
+++ b/Experimental/DistributedAuthoritySample/Assets/Scripts/GameManagement/MainMenuHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 64299a9624b2b4428a98998e7e365369

--- a/Experimental/DistributedAuthoritySample/Assets/Scripts/Services/Unity.Multiplayer.Samples.SocialHub.Services.asmdef
+++ b/Experimental/DistributedAuthoritySample/Assets/Scripts/Services/Unity.Multiplayer.Samples.SocialHub.Services.asmdef
@@ -6,6 +6,7 @@
         "GUID:5540e30183c82e84b954c033c388e06c",
         "GUID:37e17ffe38d86ae48bc3207e83ffef88",
         "GUID:6087a74f6015aae4daed9a2577a7596c",
+        "GUID:1491147abca9d7d4bb7105af628b223e",
         "GUID:707bb6c7c4ef140eeac239b4f8251af8"
     ],
     "includePlatforms": [],


### PR DESCRIPTION
### Description
This PR adds a listener the game scene to return to the main menu if a session is left/disconnected or a client is removed from said session. 
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTTB-551](https://jira.unity3d.com/browse/MTTB-551)
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for the project and/or any internal package
 - [ N/A ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
