### PR TITLE
[DistributedAuthoritySample]  MTTB-548 Hide Player Names if they are behind the camera.

### DIFF
--- a/Experimental/DistributedAuthoritySample/Assets/Scripts/UI/IngameUI/UIUtils.cs
+++ b/Experimental/DistributedAuthoritySample/Assets/Scripts/UI/IngameUI/UIUtils.cs
@@ -47,14 +47,16 @@ namespace Unity.Multiplayer.Samples.SocialHub.UI
         internal static void TranslateVEWorldToScreenspace(this VisualElement visualElement, Camera camera, Transform worldspaceTransform, float yOffset = 0f)
         {
             var positionInWorldSpace = new Vector3(worldspaceTransform.position.x, worldspaceTransform.position.y + yOffset, worldspaceTransform.position.z);
-            Vector2 screenSpacePosition = camera.WorldToScreenPoint(positionInWorldSpace);
-            if (visualElement.panel == null)
+            var screenSpacePosition = camera.WorldToScreenPoint(positionInWorldSpace);
+
+            // Point is behind the camera
+            if (screenSpacePosition.z <= 0)
             {
-                //Todo: Happens on style change can be removed when finished.
+                visualElement.style.left = -1000;
                 return;
             }
 
-            Vector2 panelSpacePosition = RuntimePanelUtils.ScreenToPanel(visualElement.panel, new Vector2(screenSpacePosition.x, Screen.height - screenSpacePosition.y));
+            var panelSpacePosition = RuntimePanelUtils.ScreenToPanel(visualElement.panel, new Vector2(screenSpacePosition.x, Screen.height - screenSpacePosition.y));
             visualElement.style.left = panelSpacePosition.x;
             visualElement.style.top = panelSpacePosition.y;
         }


### PR DESCRIPTION
### Hide Player Names if the Players are behind the camera.

World2Screenpoint returns a valid ScreenPosition even if the Worldpoint is behind the camera. Adds a check to move the VisualElement out of the Viewport if the Player is behind the camera.

### Issue Number(s)
[MTTB-548]https://jira.unity3d.com/browse/MTTB-548

Issue:
<img width="1388" alt="Screenshot 2024-10-29 at 14 42 22" src="https://github.com/user-attachments/assets/b5758e16-93b7-4ceb-a49d-1ab447ce6b14">


