### PR TITLE
fix: Distributed Authority Sample - animation transition from throwing to drop [MTTB-543]

### DIFF
--- a/Experimental/DistributedAuthoritySample/Assets/Art/Characters/PigChef/Animation/PigChef.controller
+++ b/Experimental/DistributedAuthoritySample/Assets/Art/Characters/PigChef/Animation/PigChef.controller
@@ -332,6 +332,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-3792746374383654184
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Drop
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3537950060391084986}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.74137926
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-2721922470347551880
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -740,6 +765,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -5779843509736637422}
+  - {fileID: -3792746374383654184}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Experimental/DistributedAuthoritySample/Assets/Art/Characters/PigChef/Animation/PigChef.controller
+++ b/Experimental/DistributedAuthoritySample/Assets/Art/Characters/PigChef/Animation/PigChef.controller
@@ -152,6 +152,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-5758090579146250580
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Drop
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3537950060391084986}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.87288135
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-5729041917054026846
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -264,6 +289,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 2749238805826295463}
+  - {fileID: -5758090579146250580}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -806,7 +832,7 @@ AnimatorStateMachine:
     m_Position: {x: 645.5615, y: -133.86992, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -4811572191510570762}
-    m_Position: {x: 645.5615, y: -243.86992, z: 0}
+    m_Position: {x: 640, y: -350, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 3406714481312821495}
     m_Position: {x: 305.56152, y: -133.86992, z: 0}

--- a/Experimental/DistributedAuthoritySample/Assets/Scripts/Player/AvatarInteractions.cs
+++ b/Experimental/DistributedAuthoritySample/Assets/Scripts/Player/AvatarInteractions.cs
@@ -62,6 +62,7 @@ namespace Unity.Multiplayer.Samples.SocialHub.Player
         static readonly int k_DropId = Animator.StringToHash("Drop");
         static readonly int k_ThrowId = Animator.StringToHash("Throw");
         static readonly int k_ThrowReleaseId = Animator.StringToHash("ThrowRelease");
+        static readonly int k_PickUpDefault = Animator.StringToHash("Pick-Up.Default");
 
         Vector3 m_InitialInteractColliderSize;
         Vector3 m_InitialInteractColliderLocalPosition;
@@ -193,7 +194,7 @@ namespace Unity.Multiplayer.Samples.SocialHub.Player
 
         void TryPickUp()
         {
-            if (m_PotentialPickupCollider != null && m_PotentialPickupCollider.TryGetComponent(out TransferableObject otherTransferableObject))
+            if (IsAbleToPickUp() && m_PotentialPickupCollider != null && m_PotentialPickupCollider.TryGetComponent(out TransferableObject otherTransferableObject))
             {
                 HandleOwnershipTransfer(otherTransferableObject);
             }
@@ -225,7 +226,7 @@ namespace Unity.Multiplayer.Samples.SocialHub.Player
             else if (otherNetworkObject.IsOwnershipRequestRequired)
             {
                 // if not transferable, we must request access to become owner
-                if (m_Results[0].TryGetComponent(out IOwnershipRequestable otherRequestable))
+                if (otherTransferableObject is IOwnershipRequestable otherRequestable)
                 {
                     var ownershipRequestStatus = otherNetworkObject.RequestOwnership();
                     if (ownershipRequestStatus == NetworkObject.OwnershipRequestStatus.RequestSent)
@@ -483,6 +484,13 @@ namespace Unity.Multiplayer.Samples.SocialHub.Player
                 m_PotentialPickupCollider = null;
                 m_PickUpIndicator.ClearPickup();
             }
+        }
+
+        bool IsAbleToPickUp()
+        {
+            // Get the current state info for the base layer (layer 0)
+            var currentStateInfo = m_AvatarNetworkAnimator.Animator.GetCurrentAnimatorStateInfo(1);
+            return currentStateInfo.fullPathHash == k_PickUpDefault;
         }
 
         public void NetworkUpdate(NetworkUpdateStage updateStage)


### PR DESCRIPTION
### Description
This PR enables the throwing animation to transition to the drop state.
This fixes the issue seen when a player is stuck in a throwing animation when a pot/crate is transferred or destroyed.
Technically the game was trying to transition the player back to the drop state, but the animator didn't allow that transition, since there wasn't one.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
[MTTB-543](https://jira.unity3d.com/browse/MTTB-543)
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for the project and/or any internal package
 - [ N/A ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
