### PR TITLE
[MTTB-544][MTTB-572]  Fix: Some boxes got destroyed as soon as session owner left

### DIFF
--- a/Basic/DistributedAuthoritySocialHub/Assets/Prefabs/Props/Chest_CarryableObject.prefab
+++ b/Basic/DistributedAuthoritySocialHub/Assets/Prefabs/Props/Chest_CarryableObject.prefab
@@ -102,7 +102,7 @@ PrefabInstance:
       objectReference: {fileID: -1386922736006940962, guid: 207d5e6445bda07469ed6abdda1bc59c, type: 3}
     - target: {fileID: 2004954010814667909, guid: b35b44635b9b3ec43b189ea3a1400750, type: 3}
       propertyPath: m_StartingHealth
-      value: 10
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 2004954010814667909, guid: b35b44635b9b3ec43b189ea3a1400750, type: 3}
       propertyPath: destructionVFXType

--- a/Basic/DistributedAuthoritySocialHub/Assets/Prefabs/Props/Pottery_CarryableObject.prefab
+++ b/Basic/DistributedAuthoritySocialHub/Assets/Prefabs/Props/Pottery_CarryableObject.prefab
@@ -173,11 +173,11 @@ PrefabInstance:
       objectReference: {fileID: 787550606690037956, guid: 9b46f8e0c3f5c3440892c2663f9ef3ff, type: 3}
     - target: {fileID: 2004954010814667909, guid: b35b44635b9b3ec43b189ea3a1400750, type: 3}
       propertyPath: m_StartingHealth
-      value: 10
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 2004954010814667909, guid: b35b44635b9b3ec43b189ea3a1400750, type: 3}
       propertyPath: m_CollisionDamage
-      value: 20
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 2004954010814667909, guid: b35b44635b9b3ec43b189ea3a1400750, type: 3}
       propertyPath: destructionVFXType
@@ -193,7 +193,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2093548513578380327, guid: b35b44635b9b3ec43b189ea3a1400750, type: 3}
       propertyPath: GlobalObjectIdHash
-      value: 1898126669
+      value: 1926722854
       objectReference: {fileID: 0}
     - target: {fileID: 5622352566631732085, guid: b35b44635b9b3ec43b189ea3a1400750, type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

I adjusted health and damage values from the chest and pottery prefabs in order to not have them destroyed from unintended applied forces when the session owner leaves.

### Issue Number(s)
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->
https://jira.unity3d.com/browse/MTTB-544
https://jira.unity3d.com/browse/MTTB-572

### Contribution checklist
 - [ ] Tests have been added for the project and/or any internal package
 - [ ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] JIRA ticket ID is in the PR title or at least one commit message
 - [x] Include the ticket ID number within the body message of the PR to create a hyperlink
