### PR TITLE
feat: Dynamic Addressables Network Prefabs - upgrade to 6000.0.34f1 LTS & NGO v2.2.0

### DIFF
--- a/.yamato/project.metafile
+++ b/.yamato/project.metafile
@@ -33,7 +33,7 @@ projects:
   - name: dynamicaddressablesnetworkprefabs
     path: Basic/DynamicAddressablesNetworkPrefabs
     test_editors:
-      - 2022.3
+      - 6000.0.34
     run_editor_tests: !!bool false
     run_playmode_tests: !!bool false
     test_filter:

--- a/Basic/DynamicAddressablesNetworkPrefabs/Assets/AddressableAssetsData/AssetGroups/Built In Data.asset
+++ b/Basic/DynamicAddressablesNetworkPrefabs/Assets/AddressableAssetsData/AssetGroups/Built In Data.asset
@@ -13,20 +13,9 @@ MonoBehaviour:
   m_Name: Built In Data
   m_EditorClassIdentifier: 
   m_GroupName: Built In Data
-  m_Data:
-    m_SerializedData: []
   m_GUID: 78ca99454d75a4cf8ab1b4919d288a3d
-  m_SerializeEntries:
-  - m_GUID: Resources
-    m_Address: Resources
-    m_ReadOnly: 1
-    m_SerializedLabels: []
-  - m_GUID: EditorSceneList
-    m_Address: EditorSceneList
-    m_ReadOnly: 1
-    m_SerializedLabels: []
+  m_SerializeEntries: []
   m_ReadOnly: 1
   m_Settings: {fileID: 11400000, guid: eba030a8967cd41c2b351a2d35a779c2, type: 2}
   m_SchemaSet:
-    m_Schemas:
-    - {fileID: 11400000, guid: 65678e9ce7646493db44859d98c363ec, type: 2}
+    m_Schemas: []

--- a/Basic/DynamicAddressablesNetworkPrefabs/Packages/manifest.json
+++ b/Basic/DynamicAddressablesNetworkPrefabs/Packages/manifest.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "com.unity.addressables": "1.21.19",
-    "com.unity.ai.navigation": "1.1.5",
-    "com.unity.ide.rider": "3.0.28",
+    "com.unity.addressables": "2.2.2",
+    "com.unity.ai.navigation": "2.0.5",
+    "com.unity.ide.rider": "3.0.31",
     "com.unity.ide.visualstudio": "2.0.22",
-    "com.unity.ide.vscode": "1.2.5",
-    "com.unity.multiplayer.tools": "1.1.1",
-    "com.unity.netcode.gameobjects": "1.7.1",
-    "com.unity.textmeshpro": "3.0.6",
-    "com.unity.ugui": "1.0.0",
-    "com.veriorpies.parrelsync": "https://github.com/VeriorPies/ParrelSync.git?path=/ParrelSync"
+    "com.unity.multiplayer.center": "1.0.0",
+    "com.unity.multiplayer.playmode": "1.3.3",
+    "com.unity.multiplayer.tools": "2.2.1",
+    "com.unity.netcode.gameobjects": "2.2.0",
+    "com.unity.ugui": "2.0.0",
+    "com.unity.modules.accessibility": "1.0.0"
   }
 }

--- a/Basic/DynamicAddressablesNetworkPrefabs/Packages/packages-lock.json
+++ b/Basic/DynamicAddressablesNetworkPrefabs/Packages/packages-lock.json
@@ -1,21 +1,22 @@
 {
   "dependencies": {
     "com.unity.addressables": {
-      "version": "1.21.19",
+      "version": "2.2.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.scriptablebuildpipeline": "1.21.21",
+        "com.unity.profiling.core": "1.0.2",
         "com.unity.modules.assetbundle": "1.0.0",
-        "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.scriptablebuildpipeline": "2.1.4",
         "com.unity.modules.unitywebrequestassetbundle": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.ai.navigation": {
-      "version": "1.1.5",
+      "version": "2.0.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -24,8 +25,8 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.burst": {
-      "version": "1.8.13",
-      "depth": 2,
+      "version": "1.8.18",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.mathematics": "1.2.1",
@@ -34,24 +35,26 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collections": {
-      "version": "1.2.4",
+      "version": "2.5.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.burst": "1.6.6",
-        "com.unity.test-framework": "1.1.31"
+        "com.unity.burst": "1.8.17",
+        "com.unity.test-framework": "1.4.5",
+        "com.unity.nuget.mono-cecil": "1.11.4",
+        "com.unity.test-framework.performance": "3.0.3"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.6",
+      "version": "2.0.5",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.28",
+      "version": "3.0.31",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -68,40 +71,52 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.ide.vscode": {
-      "version": "1.2.5",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.mathematics": {
-      "version": "1.2.6",
-      "depth": 2,
+      "version": "1.3.2",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.multiplayer.tools": {
-      "version": "1.1.1",
+    "com.unity.multiplayer.center": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0"
+      }
+    },
+    "com.unity.multiplayer.playmode": {
+      "version": "1.3.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.profiling.core": "1.0.0-pre.1",
-        "com.unity.nuget.newtonsoft-json": "2.0.0",
-        "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.collections": "1.1.0",
-        "com.unity.modules.uielements": "1.0.0"
+        "com.unity.nuget.newtonsoft-json": "2.0.2"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.multiplayer.tools": {
+      "version": "2.2.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.burst": "1.8.17",
+        "com.unity.collections": "2.4.0",
+        "com.unity.mathematics": "1.3.1",
+        "com.unity.profiling.core": "1.0.2",
+        "com.unity.nuget.mono-cecil": "1.11.4",
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.nuget.newtonsoft-json": "3.2.1"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.netcode.gameobjects": {
-      "version": "1.7.1",
+      "version": "2.2.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.nuget.mono-cecil": "1.10.1",
-        "com.unity.transport": "1.4.0"
+        "com.unity.transport": "2.4.0",
+        "com.unity.nuget.mono-cecil": "1.11.4"
       },
       "url": "https://packages.unity.com"
     },
@@ -127,45 +142,46 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.scriptablebuildpipeline": {
-      "version": "1.21.21",
+      "version": "2.1.4",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.33",
+      "version": "1.4.5",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.ext.nunit": "2.0.3",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.textmeshpro": {
-      "version": "3.0.6",
-      "depth": 0,
+    "com.unity.test-framework.performance": {
+      "version": "3.0.3",
+      "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.unity.ugui": "1.0.0"
+        "com.unity.test-framework": "1.1.31",
+        "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.transport": {
-      "version": "1.4.1",
+      "version": "2.4.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.collections": "1.2.4",
-        "com.unity.burst": "1.6.6",
-        "com.unity.mathematics": "1.2.6"
+        "com.unity.burst": "1.8.12",
+        "com.unity.collections": "2.2.1",
+        "com.unity.mathematics": "1.3.1"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.ugui": {
-      "version": "1.0.0",
+      "version": "2.0.0",
       "depth": 0,
       "source": "builtin",
       "dependencies": {
@@ -173,12 +189,11 @@
         "com.unity.modules.imgui": "1.0.0"
       }
     },
-    "com.veriorpies.parrelsync": {
-      "version": "https://github.com/VeriorPies/ParrelSync.git?path=/ParrelSync",
+    "com.unity.modules.accessibility": {
+      "version": "1.0.0",
       "depth": 0,
-      "source": "git",
-      "dependencies": {},
-      "hash": "f45424822189ebd875d864a17d7f03b72eafbff7"
+      "source": "builtin",
+      "dependencies": {}
     },
     "com.unity.modules.ai": {
       "version": "1.0.0",
@@ -189,6 +204,12 @@
     "com.unity.modules.assetbundle": {
       "version": "1.0.0",
       "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.hierarchycore": {
+      "version": "1.0.0",
+      "depth": 2,
       "source": "builtin",
       "dependencies": {}
     },
@@ -223,7 +244,8 @@
       "dependencies": {
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0"
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.hierarchycore": "1.0.0"
       }
     },
     "com.unity.modules.unitywebrequest": {

--- a/Basic/DynamicAddressablesNetworkPrefabs/ProjectSettings/MultiplayerManager.asset
+++ b/Basic/DynamicAddressablesNetworkPrefabs/ProjectSettings/MultiplayerManager.asset
@@ -1,0 +1,7 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!655991488 &1
+MultiplayerManager:
+  m_ObjectHideFlags: 0
+  m_EnableMultiplayerRoles: 0
+  m_StrippingTypes: {}

--- a/Basic/DynamicAddressablesNetworkPrefabs/ProjectSettings/ProjectVersion.txt
+++ b/Basic/DynamicAddressablesNetworkPrefabs/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.27f1
-m_EditorVersionWithRevision: 2022.3.27f1 (73effa14754f)
+m_EditorVersion: 6000.0.34f1
+m_EditorVersionWithRevision: 6000.0.34f1 (5ab2d9ed9190)

--- a/Basic/DynamicAddressablesNetworkPrefabs/ProjectSettings/VirtualProjectsConfig.json
+++ b/Basic/DynamicAddressablesNetworkPrefabs/ProjectSettings/VirtualProjectsConfig.json
@@ -1,0 +1,4 @@
+{
+  "PlayerTags": [],
+  "version": "1.3.3"
+}

--- a/Basic/DynamicAddressablesNetworkPrefabs/README.md
+++ b/Basic/DynamicAddressablesNetworkPrefabs/README.md
@@ -3,12 +3,9 @@
 
 # Dynamic Addressables Network Prefabs Sample
 
-[![UnityVersion](https://img.shields.io/badge/Unity%20Version:-2022.3%20LTS-57b9d3.svg?logo=unity&color=2196F3)](https://unity.com/releases/editor/whats-new/2022.3.0)
-[![NetcodeVersion](https://img.shields.io/badge/Netcode%20Version:-1.7.1-57b9d3.svg?logo=unity&color=2196F3)](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/releases/tag/ngo%2F1.7.1)*
-[![LatestRelease](https://img.shields.io/badge/Latest%20%20Github%20Release:-v1.6.0-57b9d3.svg?logo=github&color=brightgreen)](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.bitesize/releases/tag/v1.6.0)
+[![UnityVersion](https://img.shields.io/badge/Unity%20Version:-6000.0.34f1%20LTS-57b9d3.svg?logo=unity&color=2196F3)](https://unity.com/releases/editor/whats-new/6000.0.34f1)
+[![NetcodeVersion](https://img.shields.io/badge/Netcode%20Version:-2.2.0-57b9d3.svg?logo=unity&color=2196F3)](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/releases/tag/ngo%2F2.2.0)
 <br><br>
-
-*: Due to a regression in Netcode for GameObjects pertaining to the destruction of NetworkObjects when a client unsuccessfully connects, this sample has remained at v1.7.1. It will be upgraded in the near future with the latest Netcode version including a fix for the regression.
 
 The Dynamic Prefabs Sample showcases the available use-cases for the dynamic prefab system, which allows us to add new spawnable prefabs at runtime. This sample uses Addressables to load the dynamic prefab, however any GameObject with a NetworkObject component can be used, regardless of its source. This sample also uses in-game UI (created using UI Toolkit) to interface with the dynamic prefabs system with configurable options like artificial latency and network spawn timeout for easy testing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [unreleased] yyyy-mm-dd
+
+### Dynamic Addressables Network Prefabs
+
+#### Added
+- Added Multiplayer Play Mode to the project (#271)
+
+#### Changed
+- Upgraded the project to Unity 6000.0.34f1 LTS (#271) Other changes include:
+  - Netcode for GameObjects upgraded from v1.7.1 to v2.2.0
+  - ParrelSync removed from the project
+
 ## [1.10.0] 2024-12-23
 
 ### Distributed Authority Social Hub

--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
 <br><br>
 # Netcode for GameObjects Bitesize Samples
 
-[![UnityVersion](https://img.shields.io/badge/Unity%20Version:-2022.3+%20LTS-57b9d3.svg?logo=unity&color=2196F3)](https://unity.com/releases/editor/whats-new/2022.3.0)
-[![NetcodeVersion](https://img.shields.io/badge/Netcode%20Version:-2.0.0+-57b9d3.svg?logo=unity&color=2196F3)](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/releases/tag/ngo%2F2.0.0)*
+[![UnityVersion](https://img.shields.io/badge/Unity%20Version:-6000.0.0+%20LTS-57b9d3.svg?logo=unity&color=2196F3)](https://unity.com/releases/editor/whats-new/6000.0.0)
+[![NetcodeVersion](https://img.shields.io/badge/Netcode%20Version:-2.0.0+-57b9d3.svg?logo=unity&color=2196F3)](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/releases/tag/ngo%2F2.0.0)
 [![LatestRelease](https://img.shields.io/badge/Latest%20%20Github%20Release:-v1.10.0-57b9d3.svg?logo=github&color=brightgreen)](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.bitesize/releases/tag/v1.10.0)
 <br><br>
-
-*: Due to a regression in Netcode for GameObjects pertaining to the destruction of NetworkObjects when a client unsuccessfully connects, the Dynamic Addressables Network Prefabs sample has remained at v1.7.1. It will be upgraded in the near future with the latest Netcode version including a fix for the regression.
 
 This repository contains a collection of bitesize sample projects and games that showcase different techniques
 which can help you get started with development of a multiplayer 


### PR DESCRIPTION
### Description
This PR upgrades Dynamic Addressables Network Prefabs to Unity 6 and upgrades associated dependencies.
Netcode for GameObjects has been upgraded to v2.2.0.
ParrelSync has been removed from the project and Multiplayer Play Mode has been integrated.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
N/A
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for the project and/or any internal package
 - [x] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ N/A ] JIRA ticket ID is in the PR title or at least one commit message
 - [ N/A ] Include the ticket ID number within the body message of the PR to create a hyperlink
