### PR TITLE
fix: changes to unity cli source api fetching

### DIFF
--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -13,7 +13,13 @@ build_{{ project.name }}_{{ editor }}_{{ platform.name }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
-    - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple --upgrade
+{% if platform.name == "mac" -%}
+    - brew tap Unity-Technologies/homebrew-unity git@github.cds.internal.unity3d.com:unity/homebrew-unity.git
+    - brew install Unity-Technologies/homebrew-unity/unity-downloader-cli
+    - brew upgrade Unity-Technologies/homebrew-unity/unity-downloader-cli
+{% else -%}
+    - choco install unity-downloader-cli -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
+{% endif -%}
 {% if project.name == "dedicatedgameserver" -%} #dedicatedgameserver sample builds via custom editor script. This script generates client and server builds on the Mac, Windows, and Linux platforms
     - unity-downloader-cli -u {{ editor }} -c editor -c macOS -c Windows -c Linux -c macOSDedicatedServerBuildSupport -c LinuxDedicatedServerBuildSupport -c WindowsDedicatedServerBuildSupport --wait --published --fast
 {% if platform.name == "win" -%} #windows

--- a/.yamato/tests.yml
+++ b/.yamato/tests.yml
@@ -13,7 +13,13 @@ test_{{ project.name }}_{{ editor }}_{{ platform.name }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
-    - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+{% if platform.name == "mac" -%}
+    - brew tap Unity-Technologies/homebrew-unity git@github.cds.internal.unity3d.com:unity/homebrew-unity.git
+    - brew install Unity-Technologies/homebrew-unity/unity-downloader-cli
+    - brew upgrade Unity-Technologies/homebrew-unity/unity-downloader-cli
+{% else -%}
+    - choco install unity-downloader-cli -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
+{% endif -%}
     - unity-downloader-cli -u {{ editor }} -c editor -w --fast
 {% if platform.name == "win" -%} #windows
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat


### PR DESCRIPTION
### Description
Quick PR to fix the jobs failing [here](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.bitesize/pull/281). The way Unity Downloader CLI is fetched is now the recommended API.
<!---
    Please provide a description of the changes proposed in the pull request.
    Make sure your commit messages have meaningful information.
    To help us link commits and PRs to JIRA work items, please include the JIRA ticket ID in the PR title or at least of your commit messages.
-->

### Issue Number(s)
N/A
<!---
    Provide a list of fixed issues from Jira (MTT-ticketnumber) or GitHub (#issuenumber).
    This helps us understand the reasoning behind this change, what it fixes, feature being added, etc.
-->

### Contribution checklist
 - [ N/A ] Tests have been added for the project and/or any internal package
 - [ N/A ] Release notes have been added to the [project changelog](../CHANGELOG.md) file
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ N/A ] JIRA ticket ID is in the PR title or at least one commit message
 - [ N/A ] Include the ticket ID number within the body message of the PR to create a hyperlink
